### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-02-16
+
+### Bug Fixes
+
+- Address PR review feedback for bug report feature
+
+### Documentation
+
+- Add roadmap and feature voting links to README
+- Add vortix report and Nix installation to README
+- Rearrange badges, add Nix flake and npm downloads badges
+
+### Features
+
+- Add `vortix report` bug report command
+
+### Miscellaneous
+
+- **deps:** Bump the rust-minor group with 2 updates ([#40](https://github.com/Harry-kp/vortix/pull/40))
+
+
+
 ## [0.1.4] - 2026-02-12
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vortix"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.75"
 description = "Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding"


### PR DESCRIPTION



## 🤖 New release

* `vortix`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5] - 2026-02-16

### Bug Fixes

- Address PR review feedback for bug report feature

### Documentation

- Add roadmap and feature voting links to README
- Add vortix report and Nix installation to README
- Rearrange badges, add Nix flake and npm downloads badges

### Features

- Add `vortix report` bug report command

### Miscellaneous

- **deps:** Bump the rust-minor group with 2 updates ([#40](https://github.com/Harry-kp/vortix/pull/40))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).