### PR TITLE
Created simple nix flake for both build and devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1771121070,
+        "narHash": "sha256-aIlv7FRXF9q70DNJPI237dEDAznSKaXmL5lfK/Id/bI=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "a2812c19f1ed2e5ed5ce2ef7109798b575c180e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "vortix Rust TUI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, crane }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        craneLib = crane.mkLib pkgs;
+
+        commonArgs = {
+          src = craneLib.cleanCargoSource ./.;
+          strictDeps = true;
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+        vortix = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+          # Tests exercise local user state and can fail in Nix build sandboxes.
+          doCheck = false;
+        });
+      in
+      {
+        packages.default = vortix;
+        packages.vortix = vortix;
+
+        apps.default = flake-utils.lib.mkApp { drv = vortix; };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ vortix ];
+          packages = with pkgs; [
+            cargo
+            clippy
+            rustc
+            rustfmt
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
## What does this PR do?

Adds a flake.nix file which defines a package and a devshell for Nix usage. To build simple supply

```bash
nix build
```

To include in a NixOS configuration use something like this.

```nix
inputs = {
    vortix.url = "github:deephack1982/vortix";

## more inputs
};

environment.systemPackages = with pkgs; [
  inputs.sidecar.packages.${pkgs.stdenv.hostPlatform.system}.vortix
]
```
## Related Issue

None

## Type of Change

- [ ] 🐛 Bug fix
- [*] ✨ New feature
- [ ] 📖 Documentation
- [ ] 🔧 Refactor
- [ ] 🧪 Tests

## Checklist

- [ ] I ran `cargo fmt`
- [ ] I ran `cargo clippy` with no warnings
- [ ] I ran `cargo test` and all tests pass
- [ ] I updated documentation if needed
