### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-03-04
+
+### Bug Fixes
+
+- **ci:** Resolve Clippy and test failures on CI
+- Address Copilot review feedback (8 items)
+- Spurious "VPN dropped" auto-reconnect on force-kill
+- Add scrolling to help overlay
+- Isolate tests from real config dir + block mouse passthrough on overlays
+- P0 critical fixes — config viewer I/O, min terminal size, search/rename cursor
+- Address Copilot review on PR #89
+- Address Copilot review on PR #91
+- Address Copilot review on PR #92
+- Address Copilot review on PR #93
+
+### Features
+
+- V0.2.0 + v0.3.0 — refactor, reliability, and UX overhaul
+- P1 group A — duration format, throughput labels, connected badge, stale data
+- P1 group B — accessibility, panel shortcuts, context footer, log filtering
+- P2 group A — protocol in cockpit, DNS detail, expanded protocol badge
+- P2 group B — confirm switch dialog, syntax highlight & scan timestamp already done
+- P3 nice-to-have — profile sorting, latency thresholds
+
+### Ci
+
+- Pin Rust 1.91.0 in CI and fix remaining lint issues
+
+### Ui
+
+- Move toast notification from bottom-right to top-right
+
+
+
 ## [0.1.5] - 2026-02-16
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vortix"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.75"
 description = "Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding"


### PR DESCRIPTION



## 🤖 New release

* `vortix`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6] - 2026-03-04

### Bug Fixes

- **ci:** Resolve Clippy and test failures on CI
- Address Copilot review feedback (8 items)
- Spurious "VPN dropped" auto-reconnect on force-kill
- Add scrolling to help overlay
- Isolate tests from real config dir + block mouse passthrough on overlays
- P0 critical fixes — config viewer I/O, min terminal size, search/rename cursor
- Address Copilot review on PR #89
- Address Copilot review on PR #91
- Address Copilot review on PR #92
- Address Copilot review on PR #93

### Features

- V0.2.0 + v0.3.0 — refactor, reliability, and UX overhaul
- P1 group A — duration format, throughput labels, connected badge, stale data
- P1 group B — accessibility, panel shortcuts, context footer, log filtering
- P2 group A — protocol in cockpit, DNS detail, expanded protocol badge
- P2 group B — confirm switch dialog, syntax highlight & scan timestamp already done
- P3 nice-to-have — profile sorting, latency thresholds

### Ci

- Pin Rust 1.91.0 in CI and fix remaining lint issues

### Ui

- Move toast notification from bottom-right to top-right
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).