### PR TITLE
feat: P3 nice-to-have — profile sorting, latency thresholds

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -524,6 +524,7 @@ impl App {
                         );
                     }
                 }
+                KeyCode::Char('s') => self.handle_message(Message::CycleSortOrder),
                 KeyCode::Char('a') => self.handle_message(Message::ManageAuth),
                 KeyCode::Char('A') => self.handle_message(Message::ClearAuth),
                 KeyCode::Char('R') => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,8 +36,8 @@ use crate::utils;
 
 // Re-export state types for convenient access
 pub use crate::state::{
-    AuthField, ConnectionState, DetailedConnectionInfo, FocusedPanel, InputMode, Protocol, Toast,
-    ToastType, VpnProfile, DISMISS_DURATION,
+    AuthField, ConnectionState, DetailedConnectionInfo, FocusedPanel, InputMode, ProfileSortOrder,
+    Protocol, Toast, ToastType, VpnProfile, DISMISS_DURATION,
 };
 
 /// Main application state container.
@@ -121,6 +121,8 @@ pub struct App {
     pub connection_drops: u32,
     /// Profile index queued for auto-connect after current disconnect completes.
     pub pending_connect: Option<usize>,
+    /// Current sort order for the profile list.
+    pub sort_order: ProfileSortOrder,
 
     // === Kill Switch ===
     /// Kill switch operating mode (Off, Auto, `AlwaysOn`).
@@ -215,6 +217,7 @@ impl App {
             config_dir,
             connection_drops: 0,
             pending_connect: None,
+            sort_order: ProfileSortOrder::default(),
 
             // Kill switch - load from persisted state for crash recovery
             killswitch_mode: crate::state::KillSwitchMode::default(),
@@ -396,6 +399,7 @@ impl App {
             config_dir: std::env::temp_dir().join("vortix_test"),
             connection_drops: 0,
             pending_connect: None,
+            sort_order: ProfileSortOrder::default(),
             killswitch_mode: crate::state::KillSwitchMode::Off,
             killswitch_state: crate::state::KillSwitchState::Disabled,
             retry_count: 0,

--- a/src/app/profile.rs
+++ b/src/app/profile.rs
@@ -194,9 +194,37 @@ impl App {
         let _ = utils::save_profile_metadata(&metadata);
     }
 
-    /// Sort profiles alphabetically by name, updating quick slots
+    /// Sort profiles according to the current `sort_order`.
     pub(crate) fn sort_profiles(&mut self) {
-        self.profiles.sort_by(|a, b| a.name.cmp(&b.name));
+        use crate::state::ProfileSortOrder;
+        match self.sort_order {
+            ProfileSortOrder::NameAsc => {
+                self.profiles.sort_by(|a, b| a.name.cmp(&b.name));
+            }
+            ProfileSortOrder::NameDesc => {
+                self.profiles.sort_by(|a, b| b.name.cmp(&a.name));
+            }
+            ProfileSortOrder::LastUsed => {
+                self.profiles.sort_by(|a, b| {
+                    b.last_used
+                        .unwrap_or(std::time::UNIX_EPOCH)
+                        .cmp(&a.last_used.unwrap_or(std::time::UNIX_EPOCH))
+                });
+            }
+            ProfileSortOrder::Protocol => {
+                fn proto_rank(p: crate::state::Protocol) -> u8 {
+                    match p {
+                        crate::state::Protocol::WireGuard => 0,
+                        crate::state::Protocol::OpenVPN => 1,
+                    }
+                }
+                self.profiles.sort_by(|a, b| {
+                    proto_rank(a.protocol)
+                        .cmp(&proto_rank(b.protocol))
+                        .then_with(|| a.name.cmp(&b.name))
+                });
+            }
+        }
     }
 
     /// Import a profile from a file path or bulk import from directory

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -61,6 +61,7 @@ fn test_app() -> App {
         config_dir: std::env::temp_dir().join("vortix_test"),
         connection_drops: 0,
         pending_connect: None,
+        sort_order: crate::state::ProfileSortOrder::default(),
         killswitch_mode: crate::state::KillSwitchMode::Off,
         killswitch_state: crate::state::KillSwitchState::Disabled,
         retry_count: 0,
@@ -1229,5 +1230,48 @@ fn test_confirm_switch_when_already_disconnected_connects_directly() {
         matches!(app.connection_state, ConnectionState::Connecting { ref profile, .. } if profile == "vpn-b"),
         "Should connect directly when already disconnected, got {:?}",
         app.connection_state
+    );
+}
+
+#[test]
+fn test_cycle_sort_order() {
+    use crate::state::ProfileSortOrder;
+
+    let mut app = test_app();
+    add_profiles(&mut app, &["charlie", "alpha", "bravo"]);
+    app.profile_list_state.select(Some(0));
+
+    assert_eq!(app.sort_order, ProfileSortOrder::NameAsc);
+
+    app.handle_message(Message::CycleSortOrder);
+    assert_eq!(app.sort_order, ProfileSortOrder::NameDesc);
+    assert_eq!(app.profiles[0].name, "charlie");
+
+    app.handle_message(Message::CycleSortOrder);
+    assert_eq!(app.sort_order, ProfileSortOrder::LastUsed);
+
+    app.handle_message(Message::CycleSortOrder);
+    assert_eq!(app.sort_order, ProfileSortOrder::Protocol);
+
+    app.handle_message(Message::CycleSortOrder);
+    assert_eq!(app.sort_order, ProfileSortOrder::NameAsc);
+    assert_eq!(app.profiles[0].name, "alpha");
+}
+
+#[test]
+fn test_sort_preserves_selection() {
+    let mut app = test_app();
+    add_profiles(&mut app, &["charlie", "alpha", "bravo"]);
+    app.profile_list_state.select(Some(1)); // "alpha" (unsorted order)
+
+    let selected_name = app.profiles[1].name.clone();
+    assert_eq!(selected_name, "alpha");
+
+    app.handle_message(Message::CycleSortOrder); // NameAsc -> NameDesc
+
+    let new_idx = app.profile_list_state.selected().unwrap();
+    assert_eq!(
+        app.profiles[new_idx].name, "alpha",
+        "Selection should follow the profile after re-sort"
     );
 }

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -170,6 +170,25 @@ impl App {
                 connect_after,
             } => self.handle_auth_submit(idx, username, password, save, connect_after),
 
+            Message::CycleSortOrder => {
+                let selected_name = self
+                    .profile_list_state
+                    .selected()
+                    .and_then(|i| self.profiles.get(i))
+                    .map(|p| p.name.clone());
+                self.sort_order = self.sort_order.next();
+                self.sort_profiles();
+                if let Some(name) = selected_name {
+                    if let Some(new_idx) = self.profiles.iter().position(|p| p.name == name) {
+                        self.profile_list_state.select(Some(new_idx));
+                    }
+                }
+                self.show_toast(
+                    format!("Sorted: {}", self.sort_order.label()),
+                    ToastType::Info,
+                );
+            }
+
             Message::ToggleKillSwitch => self.handle_toggle_killswitch(),
 
             // System

--- a/src/message.rs
+++ b/src/message.rs
@@ -159,6 +159,10 @@ pub enum Message {
     /// Clear saved credentials for the selected profile
     ClearAuth,
 
+    // === Profile Sorting ===
+    /// Cycle profile sort order (Name A-Z → Z-A → Last Used → Protocol)
+    CycleSortOrder,
+
     // === Kill Switch ===
     /// Toggle kill switch mode (Off → Auto → `AlwaysOn` → Off)
     ToggleKillSwitch,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -15,4 +15,6 @@ mod ui;
 pub use connection::{ConnectionState, DetailedConnectionInfo};
 pub use killswitch::{KillSwitchMode, KillSwitchState};
 pub use profile::{Protocol, VpnProfile};
-pub use ui::{AuthField, FocusedPanel, InputMode, Toast, ToastType, DISMISS_DURATION};
+pub use ui::{
+    AuthField, FocusedPanel, InputMode, ProfileSortOrder, Toast, ToastType, DISMISS_DURATION,
+};

--- a/src/state/ui.rs
+++ b/src/state/ui.rs
@@ -118,6 +118,44 @@ pub enum InputMode {
     },
 }
 
+/// Profile list sort ordering.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ProfileSortOrder {
+    /// Alphabetical A → Z (default).
+    #[default]
+    NameAsc,
+    /// Alphabetical Z → A.
+    NameDesc,
+    /// Most recently used first.
+    LastUsed,
+    /// Group by protocol (`WireGuard` first, then `OpenVPN`).
+    Protocol,
+}
+
+impl ProfileSortOrder {
+    /// Cycle to the next sort order.
+    #[must_use]
+    pub fn next(self) -> Self {
+        match self {
+            Self::NameAsc => Self::NameDesc,
+            Self::NameDesc => Self::LastUsed,
+            Self::LastUsed => Self::Protocol,
+            Self::Protocol => Self::NameAsc,
+        }
+    }
+
+    /// Short label for display in the sidebar title.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::NameAsc => "A→Z",
+            Self::NameDesc => "Z→A",
+            Self::LastUsed => "Recent",
+            Self::Protocol => "Proto",
+        }
+    }
+}
+
 /// Types of toast notifications for color coding.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum ToastType {

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -683,10 +683,11 @@ fn render_profiles_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
         Style::default().fg(theme::BORDER_DEFAULT)
     };
 
+    let sort_label = app.sort_order.label();
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(border_style)
-        .title(" Profiles ");
+        .title(format!(" Profiles [{sort_label}] "));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -1796,6 +1797,13 @@ fn render_connection_details(frame: &mut Frame, app: &App, area: Rect) {
             ),
         ]));
 
+        let latency_color = if app.latency_ms < 50 {
+            theme::NORD_GREEN
+        } else if app.latency_ms < 150 {
+            theme::NORD_YELLOW
+        } else {
+            theme::NORD_RED
+        };
         text.push(Line::from(vec![
             Span::styled(
                 "  ├─ Ping (Latency)   : ",
@@ -1803,10 +1811,17 @@ fn render_connection_details(frame: &mut Frame, app: &App, area: Rect) {
             ),
             Span::styled(
                 format!("{}ms", app.latency_ms),
-                Style::default().fg(theme::TEXT_PRIMARY),
+                Style::default().fg(latency_color),
             ),
         ]));
 
+        let jitter_color = if app.jitter_ms < 5 {
+            theme::NORD_GREEN
+        } else if app.jitter_ms < 15 {
+            theme::NORD_YELLOW
+        } else {
+            theme::NORD_RED
+        };
         text.push(Line::from(vec![
             Span::styled(
                 "  ├─ Stability (Jitter): ",
@@ -1814,7 +1829,7 @@ fn render_connection_details(frame: &mut Frame, app: &App, area: Rect) {
             ),
             Span::styled(
                 format!("±{}ms", app.jitter_ms),
-                Style::default().fg(theme::TEXT_PRIMARY),
+                Style::default().fg(jitter_color),
             ),
         ]));
 

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -40,6 +40,7 @@ const HELP_TEXT: &[(&str, &[(&str, &str)])] = &[
             ("c / Enter", "Connect / disconnect"),
             ("R", "Rename profile"),
             ("v", "View config"),
+            ("s", "Cycle sort order"),
             ("a", "Manage auth (OpenVPN)"),
             ("A", "Clear saved auth"),
             ("Del", "Delete profile"),


### PR DESCRIPTION
## Summary
- **#85 Profile sorting**: Press `s` in sidebar to cycle sort order: Name A→Z → Name Z→A → Last Used → Protocol. Current sort shown in sidebar title. Selection follows the same profile after re-sort.
- **#87 Latency/jitter thresholds**: Latency and jitter values in Connection Details are now color-coded — green (good), yellow (marginal), red (poor) — matching the existing packet loss coloring.
- **#84 Last-connected timestamp**: Already implemented (displays relative time in profile list).
- **#86 Empty state**: Already implemented ("No profiles yet — press [i] to import").
- **#88 Quality indicator**: Already implemented (●●●●● dots in cockpit header + EXCELLENT/GOOD/FAIR/POOR in Details panel).

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 194 unit + 49 integration tests pass (2 new sort tests added)
- [ ] Manual: press `s` in sidebar → cycles through 4 sort modes with toast
- [ ] Manual: verify latency <50ms shows green, 50-150ms yellow, >150ms red
- [ ] Manual: verify jitter <5ms shows green, 5-15ms yellow, >15ms red

Closes #84 Closes #85 Closes #86 Closes #87 Closes #88