### PR TITLE
feat: extracted duplicate function calls, quality threshold exists in…

### DIFF
--- a/src/app/connection.rs
+++ b/src/app/connection.rs
@@ -66,27 +66,18 @@ impl App {
     /// Uses `which` to locate binaries — avoids running them directly since
     /// some tools (e.g. `wg-quick --version`) hang on macOS.
     fn check_dependencies(protocol: Protocol) -> Vec<String> {
-        fn binary_exists(name: &str) -> bool {
-            std::process::Command::new("which")
-                .arg(name)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .is_ok_and(|s| s.success())
-        }
-
         let mut missing = Vec::new();
         match protocol {
             Protocol::WireGuard => {
-                if !binary_exists("wg-quick") {
+                if !utils::binary_exists("wg-quick") {
                     missing.push("wg-quick".to_string());
                 }
-                if !binary_exists("wg") {
+                if !utils::binary_exists("wg") {
                     missing.push("wireguard-tools".to_string());
                 }
             }
             Protocol::OpenVPN => {
-                if !binary_exists("openvpn") {
+                if !utils::binary_exists("openvpn") {
                     missing.push("openvpn".to_string());
                 }
             }
@@ -96,26 +87,17 @@ impl App {
 
     /// Check for system-wide dependencies at startup and warn the user.
     pub(crate) fn check_system_dependencies(&mut self) {
-        fn binary_exists(name: &str) -> bool {
-            std::process::Command::new("which")
-                .arg(name)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .is_ok_and(|s| s.success())
-        }
-
         let mut missing: Vec<&str> = Vec::new();
 
-        if !binary_exists("curl") {
+        if !utils::binary_exists("curl") {
             missing.push("curl");
         }
 
-        if !binary_exists("openvpn") {
+        if !utils::binary_exists("openvpn") {
             missing.push("openvpn");
         }
 
-        if !binary_exists("wg-quick") {
+        if !utils::binary_exists("wg-quick") {
             missing.push("wg-quick");
         }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -16,5 +16,6 @@ pub use connection::{ConnectionState, DetailedConnectionInfo};
 pub use killswitch::{KillSwitchMode, KillSwitchState};
 pub use profile::{Protocol, VpnProfile};
 pub use ui::{
-    AuthField, FocusedPanel, InputMode, ProfileSortOrder, Toast, ToastType, DISMISS_DURATION,
+    AuthField, FocusedPanel, InputMode, ProfileSortOrder, QualityLevel, Toast, ToastType,
+    DISMISS_DURATION,
 };

--- a/src/state/ui.rs
+++ b/src/state/ui.rs
@@ -182,6 +182,27 @@ pub struct Toast {
     pub expires: Instant,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum QualityLevel {
+    #[default]
+    Excellent,
+    Fair,
+    Poor,
+}
+
+impl QualityLevel {
+    #[must_use]
+    pub fn from_metrics(packet_loss: f32, jitter_ms: u64) -> Self {
+        if packet_loss >= 5.0 || jitter_ms >= 15 {
+            Self::Poor
+        } else if packet_loss >= 1.0 || jitter_ms >= 5 {
+            Self::Fair
+        } else {
+            Self::Excellent
+        }
+    }
+}
+
 impl Toast {
     /// Check if the toast notification has expired
     #[must_use]

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1,6 +1,8 @@
+use super::helpers::centered_rect;
 use crate::app::{App, AuthField, ConnectionState, InputMode, Protocol};
+use crate::state::QualityLevel;
 use ratatui::{
-    layout::{Alignment, Constraint, Flex, Layout, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
@@ -181,16 +183,6 @@ fn render_overlays(frame: &mut Frame, app: &mut App) {
 
         super::overlays::action_menu::render(frame, &actions, &mut app.action_menu_state, title);
     }
-}
-
-/// Helper to center a rect
-fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Percentage(percent_y)]).flex(Flex::Center);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)]).flex(Flex::Center);
-
-    let [area] = vertical.areas(area);
-    let [area] = horizontal.areas(area);
-    area
 }
 
 fn render_import_overlay(frame: &mut Frame, path: &str, cursor: usize) {
@@ -526,16 +518,18 @@ fn render_cockpit_header(frame: &mut Frame, app: &App, area: Rect) {
 
             // Connection quality indicator
             let quality_indicator = if app.latency_ms > 0 {
-                if app.packet_loss >= 5.0 || app.jitter_ms >= 15 {
-                    ("●●○○○", theme::NORD_RED)
-                } else if app.packet_loss >= 1.0 || app.jitter_ms >= 5 {
-                    ("●●●○○", theme::NORD_YELLOW)
-                } else if app.latency_ms < 50 {
-                    ("●●●●●", theme::NORD_GREEN)
-                } else if app.latency_ms < 150 {
-                    ("●●●●○", theme::NORD_GREEN)
-                } else {
-                    ("●●●○○", theme::NORD_YELLOW)
+                match QualityLevel::from_metrics(app.packet_loss, app.jitter_ms) {
+                    QualityLevel::Poor => ("●●○○○", theme::NORD_RED),
+                    QualityLevel::Fair => ("●●●○○", theme::NORD_YELLOW),
+                    QualityLevel::Excellent => {
+                        if app.latency_ms < 50 {
+                            ("●●●●●", theme::NORD_GREEN)
+                        } else if app.latency_ms < 150 {
+                            ("●●●●○", theme::NORD_GREEN)
+                        } else {
+                            ("●●●○○", theme::NORD_YELLOW)
+                        }
+                    }
                 }
             } else {
                 ("─────", theme::TEXT_SECONDARY)
@@ -1779,12 +1773,10 @@ fn render_connection_details(frame: &mut Frame, app: &App, area: Rect) {
         text.push(Line::from(""));
 
         // Row 6: Quality Metrics (Unified high-density)
-        let quality_status = if app.packet_loss >= 5.0 || app.jitter_ms >= 15 {
-            ("POOR", theme::NORD_RED)
-        } else if app.packet_loss >= 1.0 || app.jitter_ms >= 5 {
-            ("FAIR", theme::NORD_YELLOW)
-        } else {
-            ("EXCELLENT", theme::NORD_GREEN)
+        let quality_status = match QualityLevel::from_metrics(app.packet_loss, app.jitter_ms) {
+            QualityLevel::Poor => ("POOR", theme::NORD_RED),
+            QualityLevel::Fair => ("FAIR", theme::NORD_YELLOW),
+            QualityLevel::Excellent => ("EXCELLENT", theme::NORD_GREEN),
         };
 
         text.push(Line::from(vec![

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,0 +1,11 @@
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+
+/// Helper to center a rect
+pub(crate) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Percentage(percent_y)]).flex(Flex::Center);
+    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)]).flex(Flex::Center);
+
+    let [area] = vertical.areas(area);
+    let [area] = horizontal.areas(area);
+    area
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 //! UI rendering module
 
 mod dashboard;
+mod helpers;
 mod overlays;
 mod widgets;
 

--- a/src/ui/overlays/config_viewer.rs
+++ b/src/ui/overlays/config_viewer.rs
@@ -2,8 +2,9 @@
 
 use crate::app::App;
 use crate::theme;
+use crate::ui::helpers::centered_rect;
 use ratatui::{
-    layout::{Constraint, Flex, Layout, Rect},
+    layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
@@ -210,14 +211,4 @@ fn mask_sensitive_value(key: &str, value: &str) -> String {
     } else {
         value.to_string()
     }
-}
-
-/// Create a centered rectangle
-fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Percentage(percent_y)]).flex(Flex::Center);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)]).flex(Flex::Center);
-
-    let [area] = vertical.areas(area);
-    let [area] = horizontal.areas(area);
-    area
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -616,6 +616,15 @@ pub fn get_unique_path(dir: &std::path::Path, filename: &str) -> std::path::Path
     path
 }
 
+pub(crate) fn binary_exists(name: &str) -> bool {
+    std::process::Command::new("which")
+        .arg(name)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
… one place

## What does this PR do?

Deduplicates three copy-pasted utility functions across the codebase:

- **`centered_rect`** — extracted to `src/ui/helpers.rs`, imported in `dashboard.rs` and `config_viewer.rs`
- **Quality thresholds** — created `QualityLevel` enum with `from_metrics()` in `src/state/ui.rs`, replacing inline threshold logic in both render sites
- **`binary_exists`** — extracted to `src/utils.rs`, imported in both callers in `connection.rs`

No behavioral changes — purely structural cleanup to eliminate divergence risk.


## Related Issue

Fixes #117 

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [x] 🔧 Refactor
- [ ] 🧪 Tests

## Checklist

- [x] I ran `cargo fmt`
- [x] I ran `cargo clippy` with no warnings
- [x] I ran `cargo test` and all tests pass
- [ ] I updated documentation if needed
