### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a CLI-first headless mode with structured JSON output for scripting, automation, and AI-agent workflows ([#176](https://github.com/Harry-kp/vortix/pull/176)).
+- Add a CLI-first headless mode with structured JSON output for scripting, automation, and AI-agent workflows, including `vortix status` for scriptable connection and kill-switch visibility ([#156](https://github.com/Harry-kp/vortix/issues/156), [#176](https://github.com/Harry-kp/vortix/pull/176)).
 - Add the new flip-panel dashboard interaction with animated card transitions ([#165](https://github.com/Harry-kp/vortix/pull/165)).
 
 ### Changed
 
-- VPN sessions can now keep running after the TUI or CLI exits, so leaving the interface no longer tears down an active connection unexpectedly ([#176](https://github.com/Harry-kp/vortix/pull/176)).
+- VPN sessions can now keep running after the TUI or CLI exits, so leaving the interface no longer tears down an active connection unexpectedly ([#155](https://github.com/Harry-kp/vortix/issues/155), [#176](https://github.com/Harry-kp/vortix/pull/176)).
 - Make `vortix down` wait for the OpenVPN daemon to fully exit before reporting success ([#176](https://github.com/Harry-kp/vortix/pull/176)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-03-31
 
-### Highlights
+### Added
 
-- Add a CLI-first headless mode with JSON output, making Vortix easier to script and automate.
-- Let VPN connections keep running after the TUI or CLI exits, so quitting Vortix no longer tears down an active session unexpectedly.
-- Introduce the new flip-panel dashboard interaction with animated card transitions ([#165](https://github.com/Harry-kp/vortix/pull/165)).
+- Add a CLI-first headless mode with structured JSON output for scripting, automation, and AI-agent workflows.
+- Add the new flip-panel dashboard interaction with animated card transitions ([#165](https://github.com/Harry-kp/vortix/pull/165)).
 
-### Improvements
+### Changed
 
+- VPN sessions can now keep running after the TUI or CLI exits, so leaving the interface no longer tears down an active connection unexpectedly.
+- Remove the stale quit confirmation because connection lifecycle is now decoupled from the UI process.
 - Make `vortix down` wait for the OpenVPN daemon to fully exit before reporting success.
-- Remove the stale quit confirmation now that active connections can continue independently of the UI process.
-- Fix help overlay scrolling edge cases, including opening before the first resize and clamping scroll correctly.
-- Tighten tests and internal error handling around CLI lifecycle behavior and edge cases.
+
+### Fixed
+
+- Fix help overlay scrolling edge cases, including opening before the first resize and clamping scroll correctly after keyboard and mouse input.
+- Harden CLI lifecycle handling and related tests around disconnect flow, error paths, and config isolation.
+
+### Documentation
+
+- Clarify current Linux support expectations and improve Linux bug-reporting guidance for distro-specific issues.
+
+### CI
+
+- Add Fedora 41 CI coverage for `cargo check`, `cargo clippy`, `cargo test`, and `cargo doc`, including unprivileged test execution for Linux-specific validation.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,27 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a CLI-first headless mode with structured JSON output for scripting, automation, and AI-agent workflows.
+- Add a CLI-first headless mode with structured JSON output for scripting, automation, and AI-agent workflows ([#176](https://github.com/Harry-kp/vortix/pull/176)).
 - Add the new flip-panel dashboard interaction with animated card transitions ([#165](https://github.com/Harry-kp/vortix/pull/165)).
 
 ### Changed
 
-- VPN sessions can now keep running after the TUI or CLI exits, so leaving the interface no longer tears down an active connection unexpectedly.
-- Remove the stale quit confirmation because connection lifecycle is now decoupled from the UI process.
-- Make `vortix down` wait for the OpenVPN daemon to fully exit before reporting success.
+- VPN sessions can now keep running after the TUI or CLI exits, so leaving the interface no longer tears down an active connection unexpectedly ([#176](https://github.com/Harry-kp/vortix/pull/176)).
+- Make `vortix down` wait for the OpenVPN daemon to fully exit before reporting success ([#176](https://github.com/Harry-kp/vortix/pull/176)).
 
 ### Fixed
 
-- Fix help overlay scrolling edge cases, including opening before the first resize and clamping scroll correctly after keyboard and mouse input.
-- Harden CLI lifecycle handling and related tests around disconnect flow, error paths, and config isolation.
+- Remove the stale quit confirmation now that active connections can continue independently of the UI process ([#179](https://github.com/Harry-kp/vortix/issues/179), [#182](https://github.com/Harry-kp/vortix/pull/182)).
+- Fix help overlay scrolling edge cases, including opening before the first resize and clamping scroll correctly after keyboard and mouse input ([#180](https://github.com/Harry-kp/vortix/issues/180), [#182](https://github.com/Harry-kp/vortix/pull/182)).
+- Harden CLI lifecycle handling around disconnect flow, error paths, and config isolation ([#176](https://github.com/Harry-kp/vortix/pull/176)).
 
 ### Documentation
 
-- Clarify current Linux support expectations and improve Linux bug-reporting guidance for distro-specific issues.
+- Clarify current Linux support expectations and improve Linux bug-reporting guidance for distro-specific issues ([#185](https://github.com/Harry-kp/vortix/pull/185)).
 
 ### CI
 
-- Add Fedora 41 CI coverage for `cargo check`, `cargo clippy`, `cargo test`, and `cargo doc`, including unprivileged test execution for Linux-specific validation.
+- Add Fedora 41 CI coverage for `cargo check`, `cargo clippy`, `cargo test`, and `cargo doc`, including unprivileged test execution for Linux-specific validation ([#160](https://github.com/Harry-kp/vortix/issues/160), [#183](https://github.com/Harry-kp/vortix/pull/183)).
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-03-31
+
+### Bug Fixes
+
+- Use checked_sub for Instant subtraction in tests
+- Address Copilot review — try_next error handling, edge cases
+- CLI connections no longer killed on process exit
+- VPN connections now persist across TUI and CLI process exits
+- Remove VPN teardown from TUI quit handler
+- Import test no longer writes to real config directory
+- CLI disconnect now waits for OpenVPN daemon to actually exit
+- Resolve all clippy warnings and Copilot review feedback
+- Backtick-wrap VpnEngine in test doc comment
+- Remove stale quit confirmation and bound help scroll
+- Initialize help scroll bounds before first resize
+- Avoid truncating cast in help overlay debug assert
+- Address Copilot review feedback on help overlay
+
+### Features
+
+- Add flip panel with animated card-flip transition ([#165](https://github.com/Harry-kp/vortix/pull/165))
+- Add CLI-first headless mode with JSON output, agent-friendly design
+
+
+
 ## [0.1.8] - 2026-03-19
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.9] - 2026-03-31
+## [0.2.0] - 2026-03-31
 
-### Bug Fixes
+### Highlights
 
-- Use checked_sub for Instant subtraction in tests
-- Address Copilot review — try_next error handling, edge cases
-- CLI connections no longer killed on process exit
-- VPN connections now persist across TUI and CLI process exits
-- Remove VPN teardown from TUI quit handler
-- Import test no longer writes to real config directory
-- CLI disconnect now waits for OpenVPN daemon to actually exit
-- Resolve all clippy warnings and Copilot review feedback
-- Backtick-wrap VpnEngine in test doc comment
-- Remove stale quit confirmation and bound help scroll
-- Initialize help scroll bounds before first resize
-- Avoid truncating cast in help overlay debug assert
-- Address Copilot review feedback on help overlay
+- Add a CLI-first headless mode with JSON output, making Vortix easier to script and automate.
+- Let VPN connections keep running after the TUI or CLI exits, so quitting Vortix no longer tears down an active session unexpectedly.
+- Introduce the new flip-panel dashboard interaction with animated card transitions ([#165](https://github.com/Harry-kp/vortix/pull/165)).
 
-### Features
+### Improvements
 
-- Add flip panel with animated card-flip transition ([#165](https://github.com/Harry-kp/vortix/pull/165))
-- Add CLI-first headless mode with JSON output, agent-friendly design
+- Make `vortix down` wait for the OpenVPN daemon to fully exit before reporting success.
+- Remove the stale quit confirmation now that active connections can continue independently of the UI process.
+- Fix help overlay scrolling edge cases, including opening before the first resize and clamping scroll correctly.
+- Tighten tests and internal error handling around CLI lifecycle behavior and edge cases.
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vortix"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 rust-version = "1.75"
 description = "Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vortix"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75"
 description = "Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding"


### PR DESCRIPTION
## 🤖 New release

* `vortix`: 0.1.8 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0] - 2026-03-31

### Added

- Add a CLI-first headless mode with structured JSON output for scripting, automation, and AI-agent workflows, including `vortix status` for scriptable connection and kill-switch visibility ([#156](https://github.com/Harry-kp/vortix/issues/156), [#176](https://github.com/Harry-kp/vortix/pull/176)).
- Add the new flip-panel dashboard interaction with animated card transitions ([#165](https://github.com/Harry-kp/vortix/pull/165)).

### Changed

- VPN sessions can now keep running after the TUI or CLI exits, so leaving the interface no longer tears down an active connection unexpectedly ([#155](https://github.com/Harry-kp/vortix/issues/155), [#176](https://github.com/Harry-kp/vortix/pull/176)).
- Make `vortix down` wait for the OpenVPN daemon to fully exit before reporting success ([#176](https://github.com/Harry-kp/vortix/pull/176)).

### Fixed

- Remove the stale quit confirmation now that active connections can continue independently of the UI process ([#179](https://github.com/Harry-kp/vortix/issues/179), [#182](https://github.com/Harry-kp/vortix/pull/182)).
- Fix help overlay scrolling edge cases, including opening before the first resize and clamping scroll correctly after keyboard and mouse input ([#180](https://github.com/Harry-kp/vortix/issues/180), [#182](https://github.com/Harry-kp/vortix/pull/182)).
- Harden CLI lifecycle handling around disconnect flow, error paths, and config isolation ([#176](https://github.com/Harry-kp/vortix/pull/176)).

### Documentation

- Clarify current Linux support expectations and improve Linux bug-reporting guidance for distro-specific issues ([#185](https://github.com/Harry-kp/vortix/pull/185)).

### CI

- Add Fedora 41 CI coverage for `cargo check`, `cargo clippy`, `cargo test`, and `cargo doc`, including unprivileged test execution for Linux-specific validation ([#160](https://github.com/Harry-kp/vortix/issues/160), [#183](https://github.com/Harry-kp/vortix/pull/183)).
</blockquote>

</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).