### PR TITLE
fix: remove stale quit confirmation and bound help scroll

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -149,8 +149,9 @@ impl App {
             InputMode::Help { mut scroll } => {
                 let max_scroll = help_max_scroll_for_terminal_height(
                     self.terminal_size.1,
-                    crate::ui::overlays::help::total_lines(),
+                    crate::ui::help_total_lines(),
                 );
+                scroll = scroll.min(max_scroll);
                 match key.code {
                     KeyCode::Esc | KeyCode::Char('?' | 'q') => {
                         self.handle_message(Message::CloseOverlay);
@@ -245,11 +246,17 @@ impl App {
                 (InputMode::Help { scroll }, MouseEventKind::ScrollDown) => {
                     let max_scroll = help_max_scroll_for_terminal_height(
                         self.terminal_size.1,
-                        crate::ui::overlays::help::total_lines(),
+                        crate::ui::help_total_lines(),
                     );
+                    *scroll = (*scroll).min(max_scroll);
                     *scroll = scroll.saturating_add(3).min(max_scroll);
                 }
                 (InputMode::Help { scroll }, MouseEventKind::ScrollUp) => {
+                    let max_scroll = help_max_scroll_for_terminal_height(
+                        self.terminal_size.1,
+                        crate::ui::help_total_lines(),
+                    );
+                    *scroll = (*scroll).min(max_scroll);
                     *scroll = scroll.saturating_sub(3);
                 }
                 _ => {}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2,9 +2,10 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::{App, AuthField, ConnectionState, FocusedPanel, InputMode, ToastType};
+use super::{App, AuthField, FocusedPanel, InputMode, ToastType};
 use crate::constants;
 use crate::message::{self, Message, ScrollMove, SelectionMove};
+use crate::state::help_max_scroll_for_terminal_height;
 
 enum ConfirmAction {
     Confirmed,
@@ -49,18 +50,9 @@ impl App {
             self.handle_message(Message::Quit);
             return;
         }
-        // 'q' in normal mode: confirm first when VPN is active.
+        // 'q' in normal mode: exit immediately. Active VPN sessions persist.
         if key.code == KeyCode::Char('q') && self.input_mode == InputMode::Normal {
-            if matches!(
-                self.connection_state,
-                ConnectionState::Connected { .. } | ConnectionState::Connecting { .. }
-            ) {
-                self.input_mode = InputMode::ConfirmQuit {
-                    confirm_selected: false,
-                };
-            } else {
-                self.handle_message(Message::Quit);
-            }
+            self.handle_message(Message::Quit);
             return;
         }
 
@@ -155,12 +147,16 @@ impl App {
                 }
             }
             InputMode::Help { mut scroll } => {
+                let max_scroll = help_max_scroll_for_terminal_height(
+                    self.terminal_size.1,
+                    crate::ui::overlays::help::total_lines(),
+                );
                 match key.code {
                     KeyCode::Esc | KeyCode::Char('?' | 'q') => {
                         self.handle_message(Message::CloseOverlay);
                     }
                     KeyCode::Down | KeyCode::Char('j') => {
-                        scroll = scroll.saturating_add(1);
+                        scroll = scroll.saturating_add(1).min(max_scroll);
                     }
                     KeyCode::Up | KeyCode::Char('k') => {
                         scroll = scroll.saturating_sub(1);
@@ -169,7 +165,7 @@ impl App {
                         scroll = 0;
                     }
                     KeyCode::Char('G') | KeyCode::End => {
-                        scroll = u16::MAX;
+                        scroll = max_scroll;
                     }
                     _ => {}
                 }
@@ -235,20 +231,6 @@ impl App {
                     }
                 }
             },
-            InputMode::ConfirmQuit {
-                mut confirm_selected,
-            } => match handle_confirm_keys(key, &mut confirm_selected) {
-                ConfirmAction::Confirmed => self.handle_message(Message::Quit),
-                ConfirmAction::Cancelled => self.handle_message(Message::CloseOverlay),
-                ConfirmAction::None => {
-                    if let InputMode::ConfirmQuit {
-                        confirm_selected: cs,
-                    } = &mut self.input_mode
-                    {
-                        *cs = confirm_selected;
-                    }
-                }
-            },
             InputMode::Normal => self.handle_normal_keys(key),
         }
     }
@@ -261,7 +243,11 @@ impl App {
         if self.input_mode != InputMode::Normal {
             match (&mut self.input_mode, mouse.kind) {
                 (InputMode::Help { scroll }, MouseEventKind::ScrollDown) => {
-                    *scroll = scroll.saturating_add(3);
+                    let max_scroll = help_max_scroll_for_terminal_height(
+                        self.terminal_size.1,
+                        crate::ui::overlays::help::total_lines(),
+                    );
+                    *scroll = scroll.saturating_add(3).min(max_scroll);
                 }
                 (InputMode::Help { scroll }, MouseEventKind::ScrollUp) => {
                     *scroll = scroll.saturating_sub(3);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1371,137 +1371,98 @@ fn test_text_field_insert_at_middle_of_multibyte() {
 }
 
 // ====================================================================
-// Confirm dialog key handling tests
+// Quit + help overlay behavior tests
 // ====================================================================
 
 #[test]
-fn test_confirm_dialog_left_selects_yes() {
+fn test_q_in_normal_mode_quits_while_connected() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     let mut app = test_app();
     add_profiles(&mut app, &["vpn-a"]);
     set_connected(&mut app, "vpn-a");
-    app.input_mode = InputMode::ConfirmQuit {
-        confirm_selected: false,
-    };
 
-    app.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
-    assert!(matches!(
-        app.input_mode,
-        InputMode::ConfirmQuit {
-            confirm_selected: true
-        }
-    ));
+    app.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+
+    assert!(app.should_quit);
+    assert!(matches!(app.input_mode, InputMode::Normal));
 }
 
 #[test]
-fn test_confirm_dialog_right_selects_no() {
+fn test_q_in_normal_mode_quits_while_disconnected() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     let mut app = test_app();
-    add_profiles(&mut app, &["vpn-a"]);
-    set_connected(&mut app, "vpn-a");
-    app.input_mode = InputMode::ConfirmQuit {
-        confirm_selected: true,
-    };
 
-    app.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
-    assert!(matches!(
-        app.input_mode,
-        InputMode::ConfirmQuit {
-            confirm_selected: false
-        }
-    ));
-}
+    app.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
 
-#[test]
-fn test_confirm_dialog_tab_toggles() {
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-
-    let mut app = test_app();
-    add_profiles(&mut app, &["vpn-a"]);
-    set_connected(&mut app, "vpn-a");
-    app.input_mode = InputMode::ConfirmQuit {
-        confirm_selected: false,
-    };
-
-    app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
-    assert!(matches!(
-        app.input_mode,
-        InputMode::ConfirmQuit {
-            confirm_selected: true
-        }
-    ));
-
-    app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
-    assert!(matches!(
-        app.input_mode,
-        InputMode::ConfirmQuit {
-            confirm_selected: false
-        }
-    ));
-}
-
-#[test]
-fn test_confirm_dialog_enter_yes_quits() {
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-
-    let mut app = test_app();
-    add_profiles(&mut app, &["vpn-a"]);
-    set_connected(&mut app, "vpn-a");
-    app.input_mode = InputMode::ConfirmQuit {
-        confirm_selected: true,
-    };
-
-    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
     assert!(app.should_quit);
 }
 
 #[test]
-fn test_confirm_dialog_enter_no_cancels() {
+fn test_help_scroll_down_clamps_at_max() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     let mut app = test_app();
-    add_profiles(&mut app, &["vpn-a"]);
-    set_connected(&mut app, "vpn-a");
-    app.input_mode = InputMode::ConfirmQuit {
-        confirm_selected: false,
-    };
+    let max_scroll = crate::state::help_max_scroll_for_terminal_height(
+        app.terminal_size.1,
+        crate::ui::overlays::help::total_lines(),
+    );
+    app.input_mode = InputMode::Help { scroll: 0 };
 
-    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-    assert!(!app.should_quit);
-    assert!(matches!(app.input_mode, InputMode::Normal));
+    for _ in 0..(usize::from(max_scroll) + 10) {
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+    }
+
+    assert!(matches!(
+        app.input_mode,
+        InputMode::Help { scroll } if scroll == max_scroll
+    ));
 }
 
 #[test]
-fn test_confirm_dialog_y_always_confirms() {
+fn test_help_end_jumps_to_max_scroll() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     let mut app = test_app();
-    add_profiles(&mut app, &["vpn-a"]);
-    set_connected(&mut app, "vpn-a");
-    app.input_mode = InputMode::ConfirmQuit {
-        confirm_selected: false,
-    };
+    let max_scroll = crate::state::help_max_scroll_for_terminal_height(
+        app.terminal_size.1,
+        crate::ui::overlays::help::total_lines(),
+    );
+    app.input_mode = InputMode::Help { scroll: 0 };
 
-    app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
-    assert!(app.should_quit, "'y' should quit regardless of selection");
+    app.handle_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
+
+    assert!(matches!(
+        app.input_mode,
+        InputMode::Help { scroll } if scroll == max_scroll
+    ));
 }
 
 #[test]
-fn test_confirm_dialog_n_always_cancels() {
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+fn test_help_mouse_scroll_down_clamps_at_max() {
+    use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
 
     let mut app = test_app();
-    add_profiles(&mut app, &["vpn-a"]);
-    set_connected(&mut app, "vpn-a");
-    app.input_mode = InputMode::ConfirmQuit {
-        confirm_selected: true,
-    };
+    let max_scroll = crate::state::help_max_scroll_for_terminal_height(
+        app.terminal_size.1,
+        crate::ui::overlays::help::total_lines(),
+    );
+    app.input_mode = InputMode::Help { scroll: 0 };
 
-    app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
-    assert!(!app.should_quit);
-    assert!(matches!(app.input_mode, InputMode::Normal));
+    for _ in 0..20 {
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        });
+    }
+
+    assert!(matches!(
+        app.input_mode,
+        InputMode::Help { scroll } if scroll == max_scroll
+    ));
 }
 
 // ====================================================================

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1406,7 +1406,7 @@ fn test_help_scroll_down_clamps_at_max() {
     let mut app = test_app();
     let max_scroll = crate::state::help_max_scroll_for_terminal_height(
         app.terminal_size.1,
-        crate::ui::overlays::help::total_lines(),
+        crate::ui::help_total_lines(),
     );
     app.input_mode = InputMode::Help { scroll: 0 };
 
@@ -1434,13 +1434,34 @@ fn test_help_scroll_does_not_move_when_terminal_size_unknown() {
 }
 
 #[test]
+fn test_help_scroll_clamps_after_resize_before_key_handling() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    let max_scroll = crate::state::help_max_scroll_for_terminal_height(
+        app.terminal_size.1,
+        crate::ui::help_total_lines(),
+    );
+    app.input_mode = InputMode::Help {
+        scroll: max_scroll.saturating_add(10),
+    };
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+
+    assert!(matches!(
+        app.input_mode,
+        InputMode::Help { scroll } if scroll == max_scroll.saturating_sub(1)
+    ));
+}
+
+#[test]
 fn test_help_end_jumps_to_max_scroll() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     let mut app = test_app();
     let max_scroll = crate::state::help_max_scroll_for_terminal_height(
         app.terminal_size.1,
-        crate::ui::overlays::help::total_lines(),
+        crate::ui::help_total_lines(),
     );
     app.input_mode = InputMode::Help { scroll: 0 };
 
@@ -1459,7 +1480,7 @@ fn test_help_mouse_scroll_down_clamps_at_max() {
     let mut app = test_app();
     let max_scroll = crate::state::help_max_scroll_for_terminal_height(
         app.terminal_size.1,
-        crate::ui::overlays::help::total_lines(),
+        crate::ui::help_total_lines(),
     );
     app.input_mode = InputMode::Help { scroll: 0 };
 
@@ -1475,6 +1496,32 @@ fn test_help_mouse_scroll_down_clamps_at_max() {
     assert!(matches!(
         app.input_mode,
         InputMode::Help { scroll } if scroll == max_scroll
+    ));
+}
+
+#[test]
+fn test_help_mouse_scroll_up_clamps_after_resize() {
+    use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+
+    let mut app = test_app();
+    let max_scroll = crate::state::help_max_scroll_for_terminal_height(
+        app.terminal_size.1,
+        crate::ui::help_total_lines(),
+    );
+    app.input_mode = InputMode::Help {
+        scroll: max_scroll.saturating_add(9),
+    };
+
+    app.handle_mouse(MouseEvent {
+        kind: MouseEventKind::ScrollUp,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    });
+
+    assert!(matches!(
+        app.input_mode,
+        InputMode::Help { scroll } if scroll == max_scroll.saturating_sub(3)
     ));
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1421,6 +1421,19 @@ fn test_help_scroll_down_clamps_at_max() {
 }
 
 #[test]
+fn test_help_scroll_does_not_move_when_terminal_size_unknown() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    app.terminal_size = (0, 0);
+    app.input_mode = InputMode::Help { scroll: 0 };
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+
+    assert!(matches!(app.input_mode, InputMode::Help { scroll: 0 }));
+}
+
+#[test]
 fn test_help_end_jumps_to_max_scroll() {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,8 @@ fn run_tui(
     let tick_rate = config.tick_rate;
     let mut app = App::new(config, config_dir);
     let events = EventHandler::new(tick_rate);
+    let size = terminal.size()?;
+    app.on_resize(size.width, size.height);
 
     // Initial draw
     app.process_external();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -16,6 +16,6 @@ pub use connection::{ConnectionState, DetailedConnectionInfo};
 pub use killswitch::{KillSwitchMode, KillSwitchState};
 pub use profile::{Protocol, VpnProfile};
 pub use ui::{
-    AuthField, FlipAnimation, FocusedPanel, InputMode, ProfileSortOrder, QualityLevel, Toast,
-    ToastType, DISMISS_DURATION,
+    help_max_scroll_for_terminal_height, AuthField, FlipAnimation, FocusedPanel, InputMode,
+    ProfileSortOrder, QualityLevel, Toast, ToastType, DISMISS_DURATION, HELP_OVERLAY_MAX_HEIGHT,
 };

--- a/src/state/ui.rs
+++ b/src/state/ui.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 
 /// Duration for toast notifications to remain visible.
 pub const DISMISS_DURATION: Duration = Duration::from_secs(4);
+pub const HELP_OVERLAY_MAX_HEIGHT: u16 = 38;
 
 /// Currently focused UI panel for keyboard navigation.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
@@ -95,11 +96,6 @@ pub enum InputMode {
         to_name: String,
         confirm_selected: bool,
     },
-    /// Confirmation dialog before quitting while VPN is connected.
-    ConfirmQuit {
-        /// Is "Yes" currently selected?
-        confirm_selected: bool,
-    },
     /// `OpenVPN` authentication credentials dialog.
     AuthPrompt {
         /// Index of the profile requiring auth.
@@ -121,6 +117,15 @@ pub enum InputMode {
         /// Whether to auto-connect after submitting (false = save-only mode).
         connect_after: bool,
     },
+}
+
+#[must_use]
+pub fn help_max_scroll_for_terminal_height(terminal_height: u16, total_lines: u16) -> u16 {
+    let overlay_height = terminal_height
+        .saturating_sub(2)
+        .min(HELP_OVERLAY_MAX_HEIGHT);
+    let inner_height = overlay_height.saturating_sub(2);
+    total_lines.saturating_sub(inner_height)
 }
 
 /// State for the panel flip animation.

--- a/src/state/ui.rs
+++ b/src/state/ui.rs
@@ -121,6 +121,10 @@ pub enum InputMode {
 
 #[must_use]
 pub fn help_max_scroll_for_terminal_height(terminal_height: u16, total_lines: u16) -> u16 {
+    if terminal_height == 0 {
+        return 0;
+    }
+
     let overlay_height = terminal_height
         .saturating_sub(2)
         .min(HELP_OVERLAY_MAX_HEIGHT);
@@ -305,6 +309,11 @@ mod tests {
     #[test]
     fn quality_fair_moderate_jitter() {
         assert_eq!(QualityLevel::from_metrics(20, 0.0, 8), QualityLevel::Fair);
+    }
+
+    #[test]
+    fn help_scroll_is_zero_when_terminal_height_unknown() {
+        assert_eq!(help_max_scroll_for_terminal_height(0, 44), 0);
     }
 
     // --- FlipAnimation tests ---

--- a/src/ui/dashboard/mod.rs
+++ b/src/ui/dashboard/mod.rs
@@ -297,20 +297,6 @@ fn render_overlays(frame: &mut Frame, app: &mut App) {
                 },
             );
         }
-        InputMode::ConfirmQuit { confirm_selected } => confirm_dialog::render(
-            frame,
-            ConfirmDialogConfig {
-                title: " Quit? ",
-                body: vec![Line::from(Span::styled(
-                    "VPN will stay connected in the background.",
-                    Style::default().fg(theme::TEXT_SECONDARY),
-                ))],
-                border_color: theme::WARNING,
-                confirm_selected: *confirm_selected,
-                width: 46,
-                height: 6,
-            },
-        ),
         InputMode::Normal => {}
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,11 +2,13 @@
 
 mod dashboard;
 mod helpers;
-pub(crate) mod overlays;
+mod overlays;
 mod widgets;
 
 use crate::app::App;
 use ratatui::Frame;
+
+pub(crate) use overlays::help::total_lines as help_total_lines;
 
 /// Main render function - dispatches to appropriate view
 pub fn render(frame: &mut Frame, app: &mut App) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,7 +2,7 @@
 
 mod dashboard;
 mod helpers;
-mod overlays;
+pub(crate) mod overlays;
 mod widgets;
 
 use crate::app::App;

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -1,6 +1,6 @@
 //! Help overlay showing all keybindings
 
-use crate::theme;
+use crate::{state, theme};
 use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
@@ -65,10 +65,25 @@ const HELP_TEXT: &[(&str, &[(&str, &str)])] = &[
     ),
 ];
 
+#[must_use]
+pub fn total_lines() -> u16 {
+    #[allow(clippy::cast_possible_truncation)]
+    {
+        HELP_TEXT
+            .iter()
+            .enumerate()
+            .map(|(section_idx, (_, bindings))| bindings.len() + 2 + usize::from(section_idx > 0))
+            .sum::<usize>() as u16
+    }
+}
+
 pub fn render(frame: &mut Frame, scroll: u16) {
     let area = frame.area();
     let width = area.width.saturating_sub(4).min(65);
-    let height = area.height.saturating_sub(2).min(38);
+    let height = area
+        .height
+        .saturating_sub(2)
+        .min(state::HELP_OVERLAY_MAX_HEIGHT);
     if width == 0 || height == 0 {
         return;
     }
@@ -109,10 +124,9 @@ pub fn render(frame: &mut Frame, scroll: u16) {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
-    let total_lines = lines.len() as u16;
-    let inner_height = height.saturating_sub(2); // borders
-    let max_scroll = total_lines.saturating_sub(inner_height);
+    debug_assert_eq!(lines.len() as u16, total_lines());
+
+    let max_scroll = state::help_max_scroll_for_terminal_height(area.height, total_lines());
     let clamped_scroll = scroll.min(max_scroll);
 
     let can_scroll_down = clamped_scroll < max_scroll;

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -124,7 +124,7 @@ pub fn render(frame: &mut Frame, scroll: u16) {
         }
     }
 
-    debug_assert_eq!(lines.len() as u16, total_lines());
+    debug_assert_eq!(u16::try_from(lines.len()), Ok(total_lines()));
 
     let max_scroll = state::help_max_scroll_for_terminal_height(area.height, total_lines());
     let clamped_scroll = scroll.min(max_scroll);


### PR DESCRIPTION
## Summary
- remove the stale `ConfirmQuit` flow so pressing `q` exits the TUI immediately while active VPN sessions keep running in the background
- clamp the help overlay's stored scroll state for keyboard and mouse input so it cannot overshoot past the visible content
- add regression tests for direct quit behavior and bounded help-overlay scrolling

Closes #179
Closes #180

## Test plan
- [x] `CARGO_HOME=\"$PWD/.cargo-home\" cargo test q_in_normal_mode_quits`
- [x] `CARGO_HOME=\"$PWD/.cargo-home\" cargo test help_`
- [x] `CARGO_HOME=\"$PWD/.cargo-home\" cargo test --lib`