### PR TITLE
ci: add Fedora jobs to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,17 @@ jobs:
       - run: cargo check
 
   check-fedora:
-    name: Check (fedora-latest)
+    name: Check (fedora-41)
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:41
     steps:
       - name: Bootstrap Fedora container
         run: dnf install -y ca-certificates curl gcc gcc-c++ git make pkgconf-pkg-config which
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.91.0"
       - uses: Swatinem/rust-cache@v2
       - run: cargo check
 
@@ -69,18 +68,18 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
 
   clippy-fedora:
-    name: Clippy (fedora-latest)
+    name: Clippy (fedora-41)
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:41
     steps:
       - name: Bootstrap Fedora container
         run: dnf install -y ca-certificates curl gcc gcc-c++ git make pkgconf-pkg-config which
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.91.0"
+          components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
 
@@ -106,21 +105,26 @@ jobs:
       - run: cargo test
 
   test-fedora:
-    name: Test (fedora-latest)
+    name: Test (fedora-41)
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:41
     steps:
       - name: Bootstrap Fedora container
         run: |
           dnf install -y ca-certificates curl gcc gcc-c++ git make nftables openvpn pkgconf-pkg-config shadow-utils which wireguard-tools
           useradd -m tester
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.91.0"
+      - uses: Swatinem/rust-cache@v2
+      - name: Prepare tester workspace and Rust toolchain
         run: |
           chown -R tester:tester "$GITHUB_WORKSPACE"
-          su - tester -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0'
-      - uses: Swatinem/rust-cache@v2
+          cp -a "$HOME/.cargo" /home/tester/
+          cp -a "$HOME/.rustup" /home/tester/
+          chown -R tester:tester /home/tester/.cargo /home/tester/.rustup
       - run: su - tester -c "cd \"$GITHUB_WORKSPACE\" && source \"\$HOME/.cargo/env\" && cargo test"
 
   docs:
@@ -141,18 +145,17 @@ jobs:
           RUSTDOCFLAGS: -D warnings
 
   docs-fedora:
-    name: Docs (fedora-latest)
+    name: Docs (fedora-41)
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:41
     steps:
       - name: Bootstrap Fedora container
         run: dnf install -y ca-certificates curl gcc gcc-c++ git make pkgconf-pkg-config which
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.91.0"
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --no-deps
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,16 @@ jobs:
       image: fedora:latest
     steps:
       - name: Bootstrap Fedora container
-        run: dnf install -y ca-certificates curl gcc gcc-c++ git make nftables openvpn pkgconf-pkg-config which wireguard-tools
+        run: |
+          dnf install -y ca-certificates curl gcc gcc-c++ git make nftables openvpn pkgconf-pkg-config shadow-utils which wireguard-tools
+          useradd -m tester
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          chown -R tester:tester "$GITHUB_WORKSPACE"
+          su - tester -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0'
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - run: su - tester -c "cd \"$GITHUB_WORKSPACE\" && source \"\$HOME/.cargo/env\" && cargo test"
 
   docs:
     name: Docs (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,22 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check
 
+  check-fedora:
+    name: Check (fedora-latest)
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - name: Bootstrap Fedora container
+        run: dnf install -y ca-certificates curl gcc gcc-c++ git make pkgconf-pkg-config which
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check
+
   fmt:
     name: Format
     runs-on: ubuntu-latest
@@ -52,6 +68,22 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
 
+  clippy-fedora:
+    name: Clippy (fedora-latest)
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - name: Bootstrap Fedora container
+        run: dnf install -y ca-certificates curl gcc gcc-c++ git make pkgconf-pkg-config which
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings
+
   test:
     name: Test (${{ matrix.os }})
     strategy:
@@ -73,6 +105,22 @@ jobs:
         run: brew install wireguard-tools openvpn
       - run: cargo test
 
+  test-fedora:
+    name: Test (fedora-latest)
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - name: Bootstrap Fedora container
+        run: dnf install -y ca-certificates curl gcc gcc-c++ git make nftables openvpn pkgconf-pkg-config which wireguard-tools
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test
+
   docs:
     name: Docs (${{ matrix.os }})
     strategy:
@@ -85,6 +133,24 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.91.0"
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  docs-fedora:
+    name: Docs (fedora-latest)
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - name: Bootstrap Fedora container
+        run: dnf install -y ca-certificates curl gcc gcc-c++ git make pkgconf-pkg-config which
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.0
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --no-deps
         env:


### PR DESCRIPTION
## Summary
- add Fedora container jobs for `cargo check`, `cargo clippy`, `cargo test`, and `cargo doc`
- bootstrap Rust 1.91.0 inside the Fedora container so CI stays aligned with the existing toolchain
- install Fedora-specific test dependencies including `wireguard-tools`, `openvpn`, and `nftables`

Closes #160

## Test plan
- [x] Parsed `.github/workflows/ci.yml` successfully with Ruby YAML
- [ ] Confirm GitHub Actions runs the new Fedora jobs on this PR
- [ ] Confirm the Fedora jobs pass on GitHub Actions