### PR TITLE
docs: add Linux support guidance and tester call

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,6 +35,16 @@ Shell:        [shell]
 Running as:   [user / root]
 ```
 
+### Linux-specific details (if applicable)
+
+```
+Distro:       [Ubuntu / Fedora / Arch / etc]
+Kernel:       [kernel version]
+Firewall:     [iptables / nftables / firewalld / unknown]
+DNS stack:    [systemd-resolved / NetworkManager / resolv.conf / unknown]
+Privilege:    [sudo vortix / root shell / other]
+```
+
 ## Dependencies
 <!--
 Tip: Run `vortix report` to auto-detect these.
@@ -59,3 +69,5 @@ Kill switch: [state]
 
 ## Additional Context
 <!-- Screenshots, error messages, log snippets (please redact any IPs or server endpoints) -->
+
+If this is a Linux issue, mention whether you can reproduce it consistently and whether it happens on a distro package install or only on a source/binary install.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,18 @@ sudo cargo run
 - 🧪 **Add tests** — Unit tests, integration tests
 - 🍎 **Linux support** — Help port macOS-specific code
 
+## Linux Help Wanted
+
+Vortix is developed primarily on macOS, so Linux users can have outsized impact.
+
+Ways Linux contributors can help:
+- Test PRs and release candidates on Ubuntu, Fedora, and Arch
+- Report distro-specific issues around firewall backends, DNS detection, and privilege handling
+- Contribute fixes for Linux-only regressions
+- Share packaging and install feedback from real systems
+
+If you regularly use Vortix on Linux and want to help more deeply, start in the [Linux tester discussion](https://github.com/Harry-kp/vortix/discussions/184) with your distro and what you are willing to test.
+
 ## Development Workflow
 
 1. Fork the repo
@@ -55,6 +67,13 @@ cargo test
 # Run with demo mode (masks sensitive data)
 sudo cargo run -- --demo
 ```
+
+For Linux bug reports, include as much of the following as possible:
+- distro + version
+- kernel version
+- install method (`cargo`, Homebrew, npm, package manager, binary installer)
+- `vortix report`
+- whether your system uses `iptables`, `nftables`, `firewalld`, `NetworkManager`, or `systemd-resolved`
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Existing options (`wg show`, NetworkManager, Tunnelblick) either lack real-time 
 - **Config Viewer** — Inspect profile configurations directly within the TUI
 - **Keyboard-driven** — No mouse required
 
+## Platform Support
+
+Vortix is actively developed and used primarily on macOS.
+
+Linux support is a current focus and is improving quickly, with CI coverage for Ubuntu and Fedora. Linux environments still vary a lot across distributions, firewall backends, DNS tooling, and privilege models, so distro-specific issues may still exist.
+
+If you use Vortix on Linux and hit a problem, please open an issue and include `vortix report` output when possible. Ubuntu, Fedora, and Arch users are especially helpful when testing release candidates and validating fixes before release. If you want to help test Linux support, join the [Linux tester discussion](https://github.com/Harry-kp/vortix/discussions/184).
+
 ## Requirements
 
 ### Runtime dependencies
@@ -153,6 +161,10 @@ After this, `sudo vortix` works as expected.
 - `npm install -g` (npm) — **no**, installs to npm global bin
 - Nix (`nix profile install`) — **no**, installs to Nix profile bin
 - macOS — **no**, sudo preserves user PATH
+
+### Linux support note
+
+Most day-to-day development happens on macOS. Linux support is continuously tested in CI, but real-world distro coverage is still growing. If something behaves differently on your Linux setup, please treat that as useful signal and report it rather than assuming it is expected.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add a clear README note that Linux support is improving but still needs broader real-world distro coverage
- expand contributor guidance for Linux testers and point people to a dedicated discussion thread
- collect Linux-specific environment details in bug reports to speed up reproduction and triage

## Test plan
- [x] reviewed the rendered markdown/content changes locally via diff
- [x] checked edited files for IDE diagnostics
- [x] no code paths changed; no runtime tests needed