### PR TITLE
fix: detect missing resolvconf before WireGuard connect on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,21 +445,39 @@ Vortix will now automatically detect `resolvconf` and proceed with the connectio
 - **Containers** with minimal kernel capabilities
 - **Custom kernels** built without netfilter support
 
-This is **not a Vortix issue** — it's a system limitation that affects all Linux VPN tools.
+This is **not a Vortix issue** — it's a system limitation that affects all Linux VPN tools, specifically:
+- **Vortix's kill switch** (requires iptables/nftables for firewall rules)
+- **wg-quick's automatic routing** (when `AllowedIPs = 0.0.0.0/0` is set in the WireGuard config)
 
-**Workaround (if you don't need the kill switch):**
+**Workaround 1: Disable the kill switch (doesn't help on cloud providers):**
 ```bash
-# Disable the kill switch (which requires iptables/nftables)
 sudo vortix killswitch off
 sudo vortix up your-profile
 ```
 
-The kill switch provides extra security by blocking all traffic if the VPN drops. Without it, you have normal firewall rules only.
+This only works if your WireGuard profile doesn't use `AllowedIPs = 0.0.0.0/0`. If it does, wg-quick will still try to configure iptables.
+
+**Workaround 2: Modify your WireGuard profile for cloud providers:**
+
+If your profile has `AllowedIPs = 0.0.0.0/0` (route all traffic through VPN), wg-quick automatically configures firewall rules. On cloud providers, change it to a more restrictive setting:
+
+```ini
+# ❌ This requires iptables (will fail on cloud providers)
+AllowedIPs = 0.0.0.0/0
+
+# ✅ This only routes VPN subnet (no iptables needed)
+AllowedIPs = 10.0.0.0/8
+```
+
+Edit your profile with `vortix show <profile> --raw` to see the current `AllowedIPs` setting.
 
 **Verify if your system supports iptables:**
 ```bash
 modprobe ip_tables && echo "✓ Supported" || echo "✗ Not available on this kernel"
 ```
+
+**Best practice for cloud providers:**
+If you need to route all traffic through the VPN on a cloud provider, you'll need an instance with a standard kernel (not a restricted cloud kernel). Alternatively, use a home server, dedicated host, or bare metal with full kernel support.
 
 #### Q: How do I know what DNS resolver my system uses?
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,16 @@ If you use Vortix on Linux and hit a problem, please open an issue and include `
 | `curl` | Pre-installed | `apt install curl` | Telemetry and IP detection |
 | `openvpn` | `brew install openvpn` | `apt install openvpn` | OpenVPN sessions |
 | `wireguard-tools` | `brew install wireguard-tools` | `apt install wireguard-tools` | WireGuard sessions |
+| `resolvconf` / `systemd-resolved` | N/A (uses native DNS) | `systemd-resolvconf` or `openresolv` | WireGuard DNS management (optional, needed if DNS in config) |
 | `iptables` or `nftables` | N/A (uses `pfctl`) | Pre-installed | Kill switch |
 | `iproute2` | N/A (uses `ifconfig`) | Pre-installed | Interface detection |
 
 > Vortix checks for missing tools at startup and shows a warning toast with install instructions.
+
+**DNS tools note:** If your WireGuard profile includes a `DNS =` directive, Vortix will automatically detect and warn about missing DNS tools. Install accordingly:
+- **Arch/Fedora (systemd-based):** `sudo pacman -S systemd-resolvconf` or `sudo dnf install systemd-resolved`
+- **Debian/Ubuntu:** `sudo apt install systemd-resolved` (usually pre-installed)
+- **Alpine/Void (OpenRC):** Vortix falls back to `/etc/resolv.conf` editing automatically
 
 ### Build dependencies (source installs only)
 
@@ -80,20 +86,20 @@ If you use Vortix on Linux and hit a problem, please open an issue and include `
 
 **Ubuntu/Debian:**
 ```bash
-sudo apt install curl wireguard-tools openvpn iptables iproute2
+sudo apt install curl wireguard-tools openvpn iptables iproute2 systemd-resolved
 ```
 
 **Fedora/RHEL:**
 ```bash
-sudo dnf install curl wireguard-tools openvpn iptables iproute
+sudo dnf install curl wireguard-tools openvpn iptables iproute systemd-resolved
 ```
 
 **Arch Linux** (only needed for source builds — `pacman -S vortix` handles deps automatically):
 ```bash
-sudo pacman -S curl wireguard-tools openvpn iptables iproute2
+sudo pacman -S curl wireguard-tools openvpn iptables iproute2 systemd-resolvconf
 ```
 
-> **DNS detection** uses `resolvectl` (systemd-resolved) as the primary method, with `nmcli` (NetworkManager) and `/etc/resolv.conf` as fallbacks. Non-systemd distros (Alpine, Void, Gentoo OpenRC) will use the `/etc/resolv.conf` fallback automatically.
+> **DNS management:** Vortix uses `resolvconf` (via `systemd-resolvconf` or `openresolv`) to manage DNS when your WireGuard profile contains `DNS =`. On systemd distros (most modern Linux), this is automatic via systemd-resolved. Non-systemd distros (Alpine, Void, Gentoo OpenRC) will use `/etc/resolv.conf` editing as a fallback.
 
 ## Installation
 
@@ -398,6 +404,16 @@ ip_api_fallbacks = ["https://api.ipify.org", "https://icanhazip.com", "https://i
 
 ## Troubleshooting
 
+### Quick Reference: Common Errors
+
+| Error Message | Cause | Solution |
+|---------------|-------|----------|
+| `Missing dependencies: resolvconf (systemd)` | WireGuard profile has DNS but `resolvconf` not installed | Run `sudo pacman -S systemd-resolvconf` (Arch) or `sudo dnf install systemd-resolved` (Fedora) |
+| `iptables-restore: unable to initialize table` | Cloud kernel doesn't support iptables; profile uses `AllowedIPs = 0.0.0.0/0` | Change `AllowedIPs` to `10.0.0.0/8` or disable kill switch |
+| `wg-quick: The config file must be a valid interface name` | Profile name > 15 characters | Rename: `vortix rename long-name short-name` |
+| `Connection succeeded but no internet` | `AllowedIPs` doesn't include your target | Add target IP to `AllowedIPs` in config |
+| `connection timed out` or `Connection refused` | Can't reach VPN endpoint | Check firewall/cloud provider port restrictions |
+
 ### General Issues
 
 **Profiles missing after upgrade (Linux)**
@@ -552,6 +568,87 @@ systemctl --version        # Init system
 ```
 
 Tested and supported Linux distros in CI: **Ubuntu 20.04/22.04**, **Fedora 40+**, **Arch Linux**. If you use a different distro and hit issues, that's valuable signal for the project.
+
+### WireGuard Configuration Guide
+
+#### Understanding AllowedIPs
+
+The `AllowedIPs` setting in your WireGuard config determines what traffic goes through the VPN:
+
+```ini
+# Route ALL traffic through VPN (requires iptables/nftables for firewall rules)
+AllowedIPs = 0.0.0.0/0          # ⚠️ May fail on cloud providers, containers
+
+# Route only VPN subnet traffic (no special firewall rules needed)
+AllowedIPs = 10.0.0.0/8          # ✅ Works everywhere, even cloud providers
+
+# Route specific traffic only
+AllowedIPs = 192.168.1.0/24      # ✅ Route only corporate network
+```
+
+**Why this matters:**
+- When `AllowedIPs = 0.0.0.0/0`, wg-quick automatically configures firewall rules via iptables/nftables
+- Cloud providers (DigitalOcean, AWS Lambda, Google Cloud Run) disable iptables kernel modules
+- Restrictive `AllowedIPs` avoids firewall configuration entirely
+
+**Recommendation for cloud servers:**
+If you're running Vortix on a cloud provider and need to route traffic through the VPN, use `AllowedIPs = 10.0.0.0/8` or another private subnet instead of `0.0.0.0/0`.
+
+#### Common WireGuard Configuration Issues
+
+**Issue: Connection succeeds but no internet access**
+
+Check your `AllowedIPs` setting:
+```bash
+vortix show your-profile --raw | grep AllowedIPs
+```
+
+- If it's `10.0.0.0/8` or similar, only traffic to that subnet goes through VPN
+- Add your target IP/subnet to `AllowedIPs` to route it through the tunnel
+- Example: `AllowedIPs = 10.0.0.0/8, 192.168.0.0/16`
+
+**Issue: Can't reach VPN server from cloud provider**
+
+Some cloud providers block outbound UDP 51820 or other ports. Try:
+```bash
+# Check if you can reach the endpoint
+ping -c 1 138.197.3.155
+
+# Test specific port (replace with your endpoint)
+nc -zu 138.197.3.155 51820 && echo "✓ Port open" || echo "✗ Port blocked"
+```
+
+If blocked, contact your cloud provider to allow WireGuard ports.
+
+**Issue: DNS works but only for some domains**
+
+This usually means:
+1. VPN DNS servers are configured but not all traffic routes through VPN
+2. Your system's DNS fallback is resolving some queries locally
+
+Check if `DNS =` is in your config and matches your VPN provider's DNS servers.
+
+#### Testing Your WireGuard Profile
+
+After creating/importing a profile, test the configuration:
+
+```bash
+# View the profile
+vortix show my-profile --raw
+
+# Check required fields
+vortix show my-profile --raw | grep -E "^(PrivateKey|PublicKey|AllowedIPs|Endpoint|Address|DNS)"
+
+# Expected output:
+# PrivateKey = (base64)
+# Address = 10.0.0.2/24
+# Endpoint = 1.2.3.4:51820
+# AllowedIPs = 10.0.0.0/8 (or 0.0.0.0/0)
+# PublicKey = (base64)
+# DNS = 8.8.8.8, 8.8.4.4 (optional)
+```
+
+All fields above are required except `DNS` (optional).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ ip_api_fallbacks = ["https://api.ipify.org", "https://icanhazip.com", "https://i
 
 ## Troubleshooting
 
+### General Issues
+
 **Profiles missing after upgrade (Linux)**
 
 If you previously ran vortix with `sudo` and profiles were stored in `/root/.config/vortix/`, the app will offer a one-time migration prompt. Accept it to move your data to `~/.config/vortix/` under your real user account.
@@ -415,6 +417,123 @@ If config files are owned by root, fix ownership:
 ```bash
 sudo chown -R $(whoami) ~/.config/vortix/
 ```
+
+### Arch Linux & Distribution-Specific FAQ
+
+#### Q: Connection fails with "Missing dependencies: resolvconf (systemd)"
+
+**A:** This happens on Arch, Fedora, and NixOS when your WireGuard profile has DNS settings but `resolvconf` isn't installed. These distros don't include DNS management tools by default.
+
+**Fix:**
+```bash
+# Arch Linux (systemd-based)
+sudo pacman -S systemd-resolvconf
+
+# Fedora (systemd-based)
+sudo dnf install systemd-resolved
+
+# Debian/Ubuntu (should be pre-installed)
+sudo apt install systemd-resolved
+```
+
+Vortix will now automatically detect `resolvconf` and proceed with the connection. No restart needed.
+
+#### Q: Connection fails with "iptables-restore: unable to initialize table"
+
+**A:** Your system doesn't have the `ip_tables` kernel module. This typically happens on:
+- **Cloud providers** (DigitalOcean, AWS Lambda, Google Cloud Run, etc.) that intentionally disable netfilter
+- **Containers** with minimal kernel capabilities
+- **Custom kernels** built without netfilter support
+
+This is **not a Vortix issue** — it's a system limitation that affects all Linux VPN tools.
+
+**Workaround (if you don't need the kill switch):**
+```bash
+# Disable the kill switch (which requires iptables/nftables)
+sudo vortix killswitch off
+sudo vortix up your-profile
+```
+
+The kill switch provides extra security by blocking all traffic if the VPN drops. Without it, you have normal firewall rules only.
+
+**Verify if your system supports iptables:**
+```bash
+modprobe ip_tables && echo "✓ Supported" || echo "✗ Not available on this kernel"
+```
+
+#### Q: How do I know what DNS resolver my system uses?
+
+**A:** Run this to check which method Vortix will use:
+
+```bash
+# Systemd (most modern Linux distros)
+resolvectl status 2>/dev/null && echo "✓ Using systemd-resolved"
+
+# NetworkManager
+nmcli dev show 2>/dev/null | grep DNS && echo "✓ Using NetworkManager"
+
+# Fallback check
+cat /etc/resolv.conf | head -3
+```
+
+Vortix automatically detects and respects your system's DNS setup.
+
+#### Q: Can I use Vortix on non-systemd distros?
+
+**A:** Yes, but with limitations on DNS management:
+- **Arch, Fedora, Ubuntu, Debian** → Full support (systemd or alternatives available)
+- **Alpine, Void, Gentoo (OpenRC)** → Vortix falls back to editing `/etc/resolv.conf` directly
+- **NixOS** → Works, but DNS may require custom configuration
+
+If you use a non-systemd distro and hit issues, please [open an issue](https://github.com/Harry-kp/vortix/issues) with `vortix report` output.
+
+#### Q: Why does the connection succeed but DNS doesn't work?
+
+**A:** If `vortix up` succeeds but you can't resolve domains, it means:
+
+1. **The VPN tunnel is active** (IP changing works)
+2. **DNS configuration failed** (resolvconf not working properly)
+
+**Debug steps:**
+```bash
+# Check if resolvconf is working
+resolvconf --version
+
+# Check active DNS servers
+resolvectl status | grep -A5 "DNS Servers"
+
+# Manually test DNS through the VPN
+dig @8.8.8.8 google.com
+
+# Check the system's resolv.conf symlink
+ls -la /etc/resolv.conf
+```
+
+If `/etc/resolv.conf` is not managed by systemd (not a symlink to `/run/systemd/`), you may need to install `systemd-resolvconf` or `openresolv`.
+
+#### Q: WireGuard interface name is too long
+
+**A:** Linux WireGuard interfaces have a 15-character name limit. If your profile name is longer, wg-quick will fail with "invalid interface name".
+
+**Fix:** Rename your profile to something shorter:
+```bash
+vortix rename my-very-long-profile-name work-vpn
+```
+
+WireGuard interface names should contain only alphanumeric characters, hyphens, and underscores.
+
+#### Q: How do I report a distro-specific issue?
+
+**A:** Include this information when opening an issue:
+
+```bash
+vortix report              # Generates a complete report
+uname -a                   # Kernel version
+cat /etc/os-release        # Distro info
+systemctl --version        # Init system
+```
+
+Tested and supported Linux distros in CI: **Ubuntu 20.04/22.04**, **Fedora 40+**, **Arch Linux**. If you use a different distro and hit issues, that's valuable signal for the project.
 
 ## Roadmap
 

--- a/src/app/connection.rs
+++ b/src/app/connection.rs
@@ -65,7 +65,7 @@ impl App {
     /// Check if required binaries are available for a given protocol.
     /// Uses `which` to locate binaries — avoids running them directly since
     /// some tools (e.g. `wg-quick --version`) hang on macOS.
-    fn check_dependencies(protocol: Protocol) -> Vec<String> {
+    fn check_dependencies(protocol: Protocol, config_path: &std::path::Path) -> Vec<String> {
         let mut missing = Vec::new();
         match protocol {
             Protocol::WireGuard => {
@@ -75,6 +75,22 @@ impl App {
                 if !utils::binary_exists("wg") {
                     missing.push("wireguard-tools".to_string());
                 }
+                // On Linux, wg-quick uses `resolvconf` to set DNS when the
+                // config contains a DNS directive.  We must verify that a
+                // working resolvconf is present — `openresolv` installed on
+                // a systemd-resolved system will exist but fail at runtime
+                // with "signature mismatch".
+                #[cfg(target_os = "linux")]
+                if utils::wireguard_config_has_dns(config_path) && !utils::resolvconf_works() {
+                    // Point the user to the right package for their system.
+                    if utils::is_systemd_resolved() {
+                        missing.push("resolvconf (systemd)".to_string());
+                    } else {
+                        missing.push("resolvconf".to_string());
+                    }
+                }
+                #[cfg(not(target_os = "linux"))]
+                let _ = config_path; // suppress unused warning on non-Linux
             }
             Protocol::OpenVPN => {
                 if !utils::binary_exists("openvpn") {
@@ -138,7 +154,7 @@ impl App {
         };
 
         // Check dependencies FIRST (no point asking for root if tool is missing)
-        let missing = Self::check_dependencies(protocol);
+        let missing = Self::check_dependencies(protocol, &config_path);
         if !missing.is_empty() {
             self.input_mode = InputMode::DependencyError { protocol, missing };
             return;

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -141,7 +141,7 @@ fn handle_up(
     // Check dependencies before attempting connection (same check as TUI)
     engine.load_metadata();
     if let Some(profile) = engine.profiles.iter().find(|p| p.name == profile_name) {
-        let (protocol, config_path) = (profile.protocol, &profile.config_path);
+        let protocol = profile.protocol;
         let mut missing = Vec::new();
 
         match protocol {
@@ -154,13 +154,16 @@ fn handle_up(
                 }
                 // Check for resolvconf on Linux when DNS is configured
                 #[cfg(target_os = "linux")]
-                if crate::utils::wireguard_config_has_dns(config_path)
-                    && !crate::utils::resolvconf_works()
                 {
-                    if crate::utils::is_systemd_resolved() {
-                        missing.push("resolvconf (systemd)".to_string());
-                    } else {
-                        missing.push("resolvconf".to_string());
+                    let config_path = &profile.config_path;
+                    if crate::utils::wireguard_config_has_dns(config_path)
+                        && !crate::utils::resolvconf_works()
+                    {
+                        if crate::utils::is_systemd_resolved() {
+                            missing.push("resolvconf (systemd)".to_string());
+                        } else {
+                            missing.push("resolvconf".to_string());
+                        }
                     }
                 }
             }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -16,6 +16,7 @@ use crate::cli::output::{
 use crate::config::AppConfig;
 use crate::constants;
 use crate::engine::VpnEngine;
+use crate::state::Protocol;
 
 /// Dispatch a CLI command. Returns `true` if handled (program should exit).
 #[must_use]
@@ -135,6 +136,63 @@ fn handle_up(
             err_permission_denied(&format!("vortix up {profile_name}")),
             ExitCode::PermissionDenied,
         );
+    }
+
+    // Check dependencies before attempting connection (same check as TUI)
+    engine.load_metadata();
+    if let Some(profile) = engine.profiles.iter().find(|p| p.name == profile_name) {
+        let (protocol, config_path) = (profile.protocol, &profile.config_path);
+        let mut missing = Vec::new();
+
+        match protocol {
+            Protocol::WireGuard => {
+                if !crate::utils::binary_exists("wg-quick") {
+                    missing.push("wg-quick".to_string());
+                }
+                if !crate::utils::binary_exists("wg") {
+                    missing.push("wireguard-tools".to_string());
+                }
+                // Check for resolvconf on Linux when DNS is configured
+                #[cfg(target_os = "linux")]
+                if crate::utils::wireguard_config_has_dns(config_path)
+                    && !crate::utils::resolvconf_works()
+                {
+                    if crate::utils::is_systemd_resolved() {
+                        missing.push("resolvconf (systemd)".to_string());
+                    } else {
+                        missing.push("resolvconf".to_string());
+                    }
+                }
+            }
+            Protocol::OpenVPN => {
+                if !crate::utils::binary_exists("openvpn") {
+                    missing.push("openvpn".to_string());
+                }
+            }
+        }
+
+        if !missing.is_empty() {
+            let hint = missing
+                .iter()
+                .map(|tool| crate::platform::install_hint(tool))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            print_error_and_exit(
+                mode,
+                "up",
+                CliError {
+                    code: "dependency_missing",
+                    message: format!(
+                        "Missing dependencies: {}. Install with: {}",
+                        missing.join(", "),
+                        hint
+                    ),
+                    hint: None,
+                },
+                ExitCode::GeneralError,
+            );
+        }
     }
 
     match engine.connect_and_wait(&profile_name, Duration::from_secs(timeout_secs)) {

--- a/src/engine/connection.rs
+++ b/src/engine/connection.rs
@@ -64,7 +64,7 @@ impl VpnEngine {
         let protocol = profile.protocol;
         let config_path = profile.config_path.clone();
 
-        let missing = Self::check_dependencies(protocol);
+        let missing = Self::check_dependencies(protocol, &config_path);
         if !missing.is_empty() {
             return Err(format!(
                 "Missing dependencies: {}. Install with: {}",

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -476,7 +476,7 @@ impl VpnEngine {
 
     /// Check if required binaries are available for a given protocol.
     #[must_use]
-    pub fn check_dependencies(protocol: Protocol) -> Vec<String> {
+    pub fn check_dependencies(protocol: Protocol, config_path: &std::path::Path) -> Vec<String> {
         let mut missing = Vec::new();
         match protocol {
             Protocol::WireGuard => {
@@ -486,6 +486,21 @@ impl VpnEngine {
                 if !utils::binary_exists("wg") {
                     missing.push("wireguard-tools".to_string());
                 }
+                // On Linux, wg-quick uses `resolvconf` to set DNS when the
+                // config contains a DNS directive.  We must verify that a
+                // working resolvconf is present — `openresolv` installed on
+                // a systemd-resolved system will exist but fail at runtime
+                // with "signature mismatch".
+                #[cfg(target_os = "linux")]
+                if utils::wireguard_config_has_dns(config_path) && !utils::resolvconf_works() {
+                    if utils::is_systemd_resolved() {
+                        missing.push("resolvconf (systemd)".to_string());
+                    } else {
+                        missing.push("resolvconf".to_string());
+                    }
+                }
+                #[cfg(not(target_os = "linux"))]
+                let _ = config_path; // suppress unused warning on non-Linux
             }
             Protocol::OpenVPN => {
                 if !utils::binary_exists("openvpn") {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -77,5 +77,26 @@ pub fn install_hint(pkg: &str) -> String {
 #[cfg(target_os = "linux")]
 #[must_use]
 pub fn install_hint(pkg: &str) -> String {
-    format!("sudo apt install {pkg}  # or: sudo dnf install {pkg}")
+    match pkg {
+        // systemd-resolved is managing DNS — need the systemd-provided shim.
+        // `openresolv` will NOT work here (causes "signature mismatch").
+        "resolvconf (systemd)" => "\
+sudo apt install systemd-resolved  # Debian/Ubuntu (provides resolvconf shim)\n\
+sudo pacman -S systemd-resolvconf  # Arch\n\
+sudo dnf install systemd-resolved  # Fedora"
+            .to_string(),
+        // Non-systemd system — standalone openresolv works fine.
+        "resolvconf" => "\
+sudo apt install openresolv  # Debian/Ubuntu\n\
+sudo pacman -S openresolv    # Arch\n\
+sudo dnf install openresolv  # Fedora"
+            .to_string(),
+        // WireGuard binaries are shipped by the wireguard-tools package.
+        "wg" | "wg-quick" => "\
+sudo apt install wireguard-tools  # Debian/Ubuntu\n\
+sudo pacman -S wireguard-tools    # Arch\n\
+sudo dnf install wireguard-tools  # Fedora"
+            .to_string(),
+        _ => format!("sudo apt install {pkg}  # or: sudo dnf install {pkg}"),
+    }
 }

--- a/src/ui/overlays/dependency_alert.rs
+++ b/src/ui/overlays/dependency_alert.rs
@@ -33,20 +33,7 @@ pub fn render(frame: &mut Frame, protocol: Protocol, missing: &[String]) {
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
 
-    let chunks = Layout::vertical([
-        Constraint::Min(0),
-        Constraint::Length(8),
-        Constraint::Min(0),
-    ])
-    .split(inner);
-
-    let pkg = if protocol == Protocol::WireGuard {
-        "wireguard-tools"
-    } else {
-        "openvpn"
-    };
-
-    let text = vec![
+    let mut text = vec![
         Line::from(""),
         Line::from(vec![
             Span::styled(
@@ -66,24 +53,43 @@ pub fn render(frame: &mut Frame, protocol: Protocol, missing: &[String]) {
         Line::from(vec![Span::raw(
             " To fix this, please run the following in your terminal:",
         )]),
-        Line::from(vec![Span::styled(
-            format!(" {}", crate::platform::install_hint(pkg)),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )]),
-        Line::from(""),
-        Line::from(vec![
-            Span::raw(" Press "),
-            Span::styled(
-                "[Esc]",
+    ];
+
+    // Show install hints per missing tool
+    for tool in missing {
+        let hint = crate::platform::install_hint(tool);
+        for hint_line in hint.lines() {
+            text.push(Line::from(vec![Span::styled(
+                format!(" {hint_line}"),
                 Style::default()
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw(" to return to dashboard."),
-        ]),
-    ];
+            )]));
+        }
+    }
+
+    text.push(Line::from(""));
+    text.push(Line::from(vec![
+        Span::raw(" Press "),
+        Span::styled(
+            "[Esc]",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" to return to dashboard."),
+    ]));
+
+    // Compute content height dynamically — cap to available space.
+    let content_height = u16::try_from(text.len())
+        .unwrap_or(u16::MAX)
+        .min(inner.height);
+    let chunks = Layout::vertical([
+        Constraint::Min(0),
+        Constraint::Length(content_height),
+        Constraint::Min(0),
+    ])
+    .split(inner);
 
     frame.render_widget(Paragraph::new(text).alignment(Alignment::Center), chunks[1]);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -631,10 +631,10 @@ pub(crate) fn resolvconf_works() -> bool {
     if !binary_exists("resolvconf") {
         return false;
     }
-    // `resolvconf -l` (list) is a read-only operation.  If `/etc/resolv.conf`
-    // was not created by openresolv it exits non-zero with "signature mismatch".
+    // Test with `--version` which works with both openresolv and systemd-resolvconf.
+    // `resolvconf -l` (list) is not supported by systemd-resolvconf's shim.
     std::process::Command::new("resolvconf")
-        .arg("-l")
+        .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -620,6 +620,67 @@ pub(crate) fn binary_exists(name: &str) -> bool {
         .is_ok_and(|s| s.success())
 }
 
+/// Check whether `resolvconf` is installed and functional.
+///
+/// Returns `true` only when the `resolvconf` binary exists **and** can
+/// operate on the current system.  `openresolv` will fail with a
+/// "signature mismatch" error when `systemd-resolved` manages
+/// `/etc/resolv.conf`, so a simple `which resolvconf` is not enough.
+#[cfg(target_os = "linux")]
+pub(crate) fn resolvconf_works() -> bool {
+    if !binary_exists("resolvconf") {
+        return false;
+    }
+    // `resolvconf -l` (list) is a read-only operation.  If `/etc/resolv.conf`
+    // was not created by openresolv it exits non-zero with "signature mismatch".
+    std::process::Command::new("resolvconf")
+        .arg("-l")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Detect whether `systemd-resolved` is managing DNS on this system.
+///
+/// Checks if `/etc/resolv.conf` is a symlink pointing into a
+/// `systemd`-owned path (e.g. `/run/systemd/resolve/`).
+#[cfg(target_os = "linux")]
+pub(crate) fn is_systemd_resolved() -> bool {
+    match std::fs::read_link("/etc/resolv.conf") {
+        Ok(target) => {
+            let s = target.to_string_lossy();
+            s.contains("systemd") || s.contains("resolvconf/run")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Check whether a `WireGuard` config file contains a `DNS =` directive.
+///
+/// When `DNS` is present, `wg-quick` on Linux will invoke `resolvconf` to
+/// manage DNS, which may not be installed on all distributions (e.g. Arch,
+/// Fedora, NixOS).  This helper lets callers detect that situation early.
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn wireguard_config_has_dns(config_path: &std::path::Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(config_path) else {
+        return false;
+    };
+    for line in content.lines() {
+        let trimmed = line.trim().to_lowercase();
+        if trimmed.starts_with("dns") {
+            // Match "dns = …" with optional whitespace around '='
+            if let Some(rest) = trimmed.strip_prefix("dns") {
+                let rest = rest.trim_start();
+                if rest.starts_with('=') {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -965,5 +1026,76 @@ mod tests {
         assert!(read_openvpn_saved_auth(name).is_none());
 
         delete_openvpn_auth_file(name);
+    }
+
+    // --- wireguard_config_has_dns tests ---
+
+    #[test]
+    fn test_wg_config_has_dns_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wg0.conf");
+        std::fs::write(
+            &path,
+            "[Interface]\nPrivateKey = abc\nAddress = 10.0.0.2/24\nDNS = 1.1.1.1\n\n[Peer]\nPublicKey = xyz\nEndpoint = 1.2.3.4:51820\n",
+        )
+        .unwrap();
+        assert!(wireguard_config_has_dns(&path));
+    }
+
+    #[test]
+    fn test_wg_config_has_dns_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wg0.conf");
+        std::fs::write(
+            &path,
+            "[Interface]\nPrivateKey = abc\nAddress = 10.0.0.2/24\n\n[Peer]\nPublicKey = xyz\nEndpoint = 1.2.3.4:51820\n",
+        )
+        .unwrap();
+        assert!(!wireguard_config_has_dns(&path));
+    }
+
+    #[test]
+    fn test_wg_config_has_dns_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wg0.conf");
+        std::fs::write(
+            &path,
+            "[Interface]\nPrivateKey = abc\nAddress = 10.0.0.2/24\ndns = 8.8.8.8\n\n[Peer]\nPublicKey = xyz\nEndpoint = 1.2.3.4:51820\n",
+        )
+        .unwrap();
+        assert!(wireguard_config_has_dns(&path));
+    }
+
+    #[test]
+    fn test_wg_config_has_dns_with_spaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wg0.conf");
+        std::fs::write(
+            &path,
+            "[Interface]\nPrivateKey = abc\nAddress = 10.0.0.2/24\n  DNS  =  1.1.1.1, 8.8.8.8\n\n[Peer]\nPublicKey = xyz\nEndpoint = 1.2.3.4:51820\n",
+        )
+        .unwrap();
+        assert!(wireguard_config_has_dns(&path));
+    }
+
+    #[test]
+    fn test_wg_config_has_dns_nonexistent_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.conf");
+        assert!(!wireguard_config_has_dns(&path));
+    }
+
+    #[test]
+    fn test_wg_config_dns_in_comment_not_matched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wg0.conf");
+        // A comment like "# DNS = ..." should not be matched since it starts
+        // with '#', not 'dns' after trimming.
+        std::fs::write(
+            &path,
+            "[Interface]\nPrivateKey = abc\nAddress = 10.0.0.2/24\n# DNS = 1.1.1.1\n\n[Peer]\nPublicKey = xyz\nEndpoint = 1.2.3.4:51820\n",
+        )
+        .unwrap();
+        assert!(!wireguard_config_has_dns(&path));
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -105,9 +105,11 @@ fn engine_sort_profiles_by_protocol() {
 
 #[test]
 fn engine_check_dependencies_wireguard() {
-    let missing = VpnEngine::check_dependencies(Protocol::WireGuard);
+    // Use a dummy config path — the resolvconf check only matters on Linux
+    let dummy = std::path::Path::new("/dev/null");
+    let missing = VpnEngine::check_dependencies(Protocol::WireGuard, dummy);
     // In test env, wg-quick/wg may or may not be available; just ensure no panic
-    assert!(missing.len() <= 2);
+    assert!(missing.len() <= 3); // wg-quick, wg, and possibly resolvconf on Linux
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds pre-flight check for `resolvconf` on Linux when WireGuard config contains `DNS =` lines
- Shows dependency error popup with distro-specific install instructions (apt/pacman/dnf)
- Adds `wireguard_config_has_dns()` utility with 6 unit tests

Closes #186
Now you will see
<img width="967" height="565" alt="image" src="https://github.com/user-attachments/assets/c47587cb-0be9-4f07-83e3-3177e30d9b4d" />
