### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Detect missing `resolvconf` before WireGuard connect on Linux, with automatic distro-specific install hints ([#186](https://github.com/Harry-kp/vortix/pull/186))
+- Detect missing `resolvconf` before WireGuard connect on Linux ([#186](https://github.com/Harry-kp/vortix/issues/186), [#187](https://github.com/Harry-kp/vortix/pull/187)) — Vortix now shows clear install instructions instead of cryptic wg-quick errors when DNS is configured but resolvconf isn't available on Arch/Fedora
 - Add CLI dependency check to catch missing tools before connection attempts
 - Fix systemd-resolvconf compatibility by testing `--version` instead of `resolvconf -l`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect missing `resolvconf` before WireGuard connect on Linux ([#186](https://github.com/Harry-kp/vortix/issues/186), [#187](https://github.com/Harry-kp/vortix/pull/187)) — Vortix now shows clear install instructions instead of cryptic wg-quick errors when DNS is configured but resolvconf isn't available on Arch/Fedora
 - Add CLI dependency check to catch missing tools before connection attempts
 
+### Documentation
+
+- Add comprehensive Arch Linux troubleshooting FAQ and distribution-specific guidance in README
+- Add WireGuard configuration guide explaining AllowedIPs, cloud provider limitations, and routing best practices
+- Add quick error reference table for common connection issues
+
 
 
 ## [0.2.0] - 2026-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Detect missing `resolvconf` before WireGuard connect on Linux ([#186](https://github.com/Harry-kp/vortix/issues/186), [#187](https://github.com/Harry-kp/vortix/pull/187)) — Vortix now shows clear install instructions instead of cryptic wg-quick errors when DNS is configured but resolvconf isn't available on Arch/Fedora
 - Add CLI dependency check to catch missing tools before connection attempts
-- Fix systemd-resolvconf compatibility by testing `--version` instead of `resolvconf -l`
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.1] - 2026-04-04
 
-### Bug Fixes
+### Fixed
 
-- Detect missing resolvconf before WireGuard connect on Linux ([#186](https://github.com/Harry-kp/vortix/pull/186))
-- Add dependency check to CLI connect command
-- Suppress unused variable warning on macOS
-- Use --version test for systemd-resolvconf compatibility
-
-### Documentation
-
-- Add Arch Linux & distribution-specific FAQ to troubleshooting
-- Clarify iptables error and wg-quick routing on cloud providers
-- Expand troubleshooting and add WireGuard configuration guide
+- Detect missing `resolvconf` before WireGuard connect on Linux, with automatic distro-specific install hints ([#186](https://github.com/Harry-kp/vortix/pull/186))
+- Add CLI dependency check to catch missing tools before connection attempts
+- Fix systemd-resolvconf compatibility by testing `--version` instead of `resolvconf -l`
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-04
+
+### Bug Fixes
+
+- Detect missing resolvconf before WireGuard connect on Linux ([#186](https://github.com/Harry-kp/vortix/pull/186))
+- Add dependency check to CLI connect command
+- Suppress unused variable warning on macOS
+- Use --version test for systemd-resolvconf compatibility
+
+### Documentation
+
+- Add Arch Linux & distribution-specific FAQ to troubleshooting
+- Clarify iptables error and wg-quick routing on cloud providers
+- Expand troubleshooting and add WireGuard configuration guide
+
+
+
 ## [0.2.0] - 2026-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vortix"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.75"
 description = "Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding"


### PR DESCRIPTION
## 🤖 New release

* `vortix`: 0.2.0 -> 0.2.1

### Fixed

- Detect missing `resolvconf` before WireGuard connect on Linux, with automatic distro-specific install hints ([#186](https://github.com/Harry-kp/vortix/pull/186))
- Add CLI dependency check to catch missing tools before connection attempts
- Fix systemd-resolvconf compatibility by testing `--version` instead of `resolvconf -l`

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).