### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-23
+
+### Miscellaneous
+
+- Update Cargo.lock dependencies
+
+
+
 ## [0.2.1] - 2026-04-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vortix"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.75"
 description = "Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding"


### PR DESCRIPTION



## 🤖 New release

* `vortix`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2] - 2026-04-23

### Miscellaneous

- Update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).