### PR TITLE
docs: align v0.3.0 docs with hook rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Existing options (`wg show`, NetworkManager, Tunnelblick) either lack real-time 
 - **Kill Switch** — Built-in firewall management for maximum security
 - **Encrypted credential store** *(new in v0.3.0)* — OS keyring (Keychain / Secret Service) with AES-256-GCM + argon2id encrypted-file fallback for headless installs
 - **Session event journal** *(new in v0.3.0)* — JSONL event log per session under `${XDG_DATA_HOME}/vortix/sessions/`, 30-day retention; useful for diagnostics and scripting
-- **Lifecycle hooks** *(new in v0.3.0)* — `[[hooks]]` in `settings.toml` runs shell commands on FSM transitions (pre/post connect/disconnect, connect_failed, reconnecting); composable with your existing workflow
 - **Per-process socket audit** *(new in v0.3.0)* — `vortix audit` answers "is this traffic actually routing through the tunnel?" with per-PID socket inventory; Linux + macOS supported
 - **Versioned structured output** *(new in v0.3.0)* — every `--json` envelope carries `schema_version: 1` so consumers can detect breaking changes instead of finding them at runtime
 - **Interactive Import** — Easily add new profiles directly within the TUI
@@ -266,18 +265,13 @@ vortix daemon --socket /tmp/vortix.sock       # custom path
 vortix show work-vpn --raw --inline-secrets > /tmp/work-with-creds.ovpn
 ```
 
-Lifecycle hooks land as a `settings.toml`-driven seam — add
-`[[hooks]]` entries to fire shell commands on FSM transitions
-(pre/post connect/disconnect, connect_failed, reconnecting). Empty by
-default, zero overhead.
-
 The Engine FSM, JSONL session journal, layered settings, and sidecar
 migration all live behind existing commands — the journal path
 surfaces in `vortix info` output, the migration runs at startup, and
 `settings.toml` works whether or not you ever create one.
 
 See [`docs/MIGRATION.md`](docs/MIGRATION.md) for the upgrade guide and
-opt-in details on the secret store, journal, hooks, and daemon.
+opt-in details on the secret store, journal, and daemon.
 
 **JSON output for AI agents / scripts:**
 ```bash

--- a/docs/architecture-migration-v1.md
+++ b/docs/architecture-migration-v1.md
@@ -190,7 +190,7 @@ plan docs remain the design records.
 
 | Phase | Plan | Status | Commit |
 |---|---|---|---|
-| A — Lifecycle hooks | 009 | ✅ shipped | `ee5b099` |
+| A — Lifecycle hooks | 009 | ⏭ deferred to v0.3.x (rolled back from PR #201) | — |
 | B — CI integration tests | 012 | ✅ shipped (Ubuntu only) | `1cbfa90` |
 | C — Socket audit port | 013 | ✅ shipped (Linux + macOS) | `82ba6a4` |
 | D — IPC layer / daemon | 010 | ✅ shipped (skeleton + wire contract); engine routing → v0.3.x | `a7796d1` |

--- a/docs/plans/2026-05-24-009-feat-lifecycle-hooks-plan.md
+++ b/docs/plans/2026-05-24-009-feat-lifecycle-hooks-plan.md
@@ -2,7 +2,7 @@
 plan_id: 2026-05-24-009
 title: "feat: Lifecycle hooks (pre/post connect/disconnect)"
 type: feat
-status: completed
+status: deferred-to-v0.3.x
 created: 2026-05-24
 target_version: 0.4.0
 target_branch: TBD (post v0.3.0 GA)

--- a/docs/plans/2026-05-24-015-feat-deferred-subsystems-bundle-plan.md
+++ b/docs/plans/2026-05-24-015-feat-deferred-subsystems-bundle-plan.md
@@ -2,7 +2,7 @@
 plan_id: 2026-05-24-015
 title: "feat: Execute deferred subsystems 009-013 in v0.3.0 bundle"
 type: feat
-status: completed
+status: completed-with-phase-a-rollback
 created: 2026-05-24
 target_branch: refactor/architectural-migration-v1
 target_pr: 201
@@ -16,6 +16,15 @@ related_plans:
 ---
 
 # feat: Execute deferred subsystems 009-013 in v0.3.0 bundle
+
+> **Phase A (Lifecycle hooks) rolled back from PR #201** — the
+> maintainer cancelled the hook surface after first hands-on use of
+> the management TUI shipped on top in plans 016/017/018. All hook
+> code (`vortix-core::engine::hooks`, `vortix-config::HookConfig`,
+> `vortix::hooks::ShellHook`, journal-subscriber wiring, plus the
+> entire TUI surface) reverted via the "Defer all hook work" commit.
+> Phases B (CI), C (audit), D (daemon), E (privilege docs) remain
+> shipped. Lifecycle hooks resume in v0.3.x with another UX iteration.
 
 ## Problem Frame
 

--- a/docs/v0.3.0-RELEASE-NOTES.md
+++ b/docs/v0.3.0-RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # Vortix v0.3.0 — what's new
 
-**v0.3.0 is the architectural migration v1 ship + the deferred-subsystems bundle.** Existing CLI commands are unchanged. Three new top-level subcommands (`secrets`, `audit`, `daemon`) earn their slots — each a real new noun with no pre-existing equivalent. Lifecycle hooks land as a journal-driven seam configurable from `settings.toml`. CI integration tests against real `wg-quick` + `openvpn` ship as a netns harness. Daemon authentication posture documented in `SECURITY.md`; engine routing through the daemon ships as v0.3.x hardening.
+**v0.3.0 is the architectural migration v1 ship + the deferred-subsystems bundle.** Existing CLI commands are unchanged. Three new top-level subcommands (`secrets`, `audit`, `daemon`) earn their slots — each a real new noun with no pre-existing equivalent. CI integration tests against real `wg-quick` + `openvpn` ship as a netns harness. Daemon authentication posture documented in `SECURITY.md`; engine routing through the daemon ships as v0.3.x hardening. **Lifecycle hooks are deferred to v0.3.x** — the brainstorm and architectural sketches stay on file, but the implementation rolls back to give the UX another design iteration.
 
 ## Highlights
 
@@ -9,12 +9,10 @@
   `${XDG_DATA_HOME}/vortix/sessions/*.jsonl` with 30-day / 30-file
   retention. The session path is surfaced via `vortix info`; you tail
   it with `tail -f` + `jq`.
-- **Lifecycle hooks** (issue [#36](https://github.com/Harry-kp/vortix/issues/36)).
-  Run shell commands on FSM transitions (`pre_connect`, `post_connect`,
-  `pre_disconnect`, `post_disconnect`, `connect_failed`, `reconnecting`).
-  Configure via `[[hooks]]` entries in `settings.toml`. Empty by default,
-  zero overhead. Hooks fire async via journal subscribe and never block
-  the FSM.
+- ~~**Lifecycle hooks**~~ — deferred to v0.3.x. The architectural
+  groundwork (journal broadcast bus, schema brainstorm, TUI surface
+  design) stays on file; the implementation lands in a future
+  iteration after another UX pass.
 - **`vortix audit`** (issues [#168](https://github.com/Harry-kp/vortix/issues/168),
   [#166](https://github.com/Harry-kp/vortix/issues/166)). Per-process
   socket snapshot — `vortix audit --pid <N>` filters to one process,


### PR DESCRIPTION
## Summary

PR #201 rolled back all lifecycle-hook work before merge (plan 015 phase A subsystem + plans 016/017/018 TUI surface). The code-side landed cleanly, but the doc-side updates were never committed — they were unstaged in my local working tree during the squash that landed `a9e794b`. As a result, **v0.3.0 docs on `main` still promise hooks as a shipped feature** while the code has none.

This PR closes that gap. Docs-only. No code change.

## What changes

| File | Change |
|---|---|
| `README.md` | Remove "Lifecycle hooks (new in v0.3.0)" feature bullet; remove the "Lifecycle hooks land as a `settings.toml`-driven seam" paragraph farther down |
| `docs/v0.3.0-RELEASE-NOTES.md` | Drop the hooks bullet from Highlights; replace with strikethrough "~~Lifecycle hooks~~ — deferred to v0.3.x" entry. Update opening paragraph to drop the "lifecycle hooks land as a journal-driven seam" promise |
| `docs/architecture-migration-v1.md` | Flip phase A row in the deferred-subsystems table from "✅ shipped" to "⏭ deferred to v0.3.x (rolled back from PR #201)"; blank the commit-hash column |
| `docs/plans/2026-05-24-009-feat-lifecycle-hooks-plan.md` | Status frontmatter `completed` → `deferred-to-v0.3.x` |
| `docs/plans/2026-05-24-015-feat-deferred-subsystems-bundle-plan.md` | Status `completed` → `completed-with-phase-a-rollback`; add a top-of-doc note explaining the rollback so future readers don't have to reconstruct the story from git history |

## What's NOT in this PR (intentionally)

`docs/architecture-migration-v1.md` references commit hashes for phases B/C/D/E (`1cbfa90`, `82ba6a4`, `a7796d1`, `f8f97e9`) that don't exist on `main` because PR #201 was squash-merged into a single commit. Those references are technically dangling. Out of scope here — fixable later as a separate housekeeping pass if desired.

Brainstorm + design memory for hooks is preserved at the local tag `backup/pre-hook-revert` on the maintainer-account checkout for whoever picks v0.3.x hooks up.

## Verification

| Gate | Status |
|---|---|
| `cargo build --workspace` | ✅ green |
| `cargo test --workspace` | ✅ ~480 tests, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ clean |
| `scripts/smoke-v0.3.0.sh dev` | ✅ 12 PASS, 0 FAIL |

## Test plan

- [x] Workspace builds + tests
- [x] Smoke 12/12
- [x] Visual review of README + RELEASE-NOTES surface text
- [ ] Merge before the v0.3.0 release-plz PR cuts so the released docs match the released code

🤖 Generated with [Claude Code](https://claude.com/claude-code)



tmp
I'm the maintainer of vortix (https://github.com/Harry-kp/vortix). I just
  merged PR #201 into main as a squash-merge (commit acd8183 — the
  architectural migration v1 bundle, shipping as v0.3.0). I want to walk
  through the release process from where we are now to v0.3.0 actually
  being installable via `cargo install vortix`, npm, and homebrew.

  Context you should establish first by reading the repo:

  1. Read `docs/RELEASE-PLAYBOOK-v0.3.0.md` — that's the canonical
     runbook. Eight stages, RC → soak → GA.
  2. Read `docs/v0.3.0-RELEASE-NOTES.md` and `docs/MIGRATION.md` so you
     know what users will see.
  3. Check `git log --oneline main | head -3` — confirm main is at the
     v0.3.0 merge commit.
  4. Check `gh pr list --state open` — PR #203 is an open docs-only