### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,7 +2333,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["crates/*"]
 default-members = ["crates/vortix"]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/crates/vortix/CHANGELOG.md
+++ b/crates/vortix/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.3.0] - 2026-05-24
+
+### Documentation
+
+- Align v0.3.0 docs with hook rollback
+
+### Refactor
+
+- Architectural migration v1 — workspace + ports + FSM + secrets (6-plan bundle)
+
+


### PR DESCRIPTION



## 🤖 New release

* `vortix`: 0.2.2 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0] - 2026-05-24

### Documentation

- Align v0.3.0 docs with hook rollback

### Refactor

- Architectural migration v1 — workspace + ports + FSM + secrets (6-plan bundle)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).