### PR TITLE
fix(config): route fix_ownership messages through tracing, not eprintln

### DIFF
--- a/crates/vortix/src/config.rs
+++ b/crates/vortix/src/config.rs
@@ -433,15 +433,36 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
 /// Simple rule: anything under the user's home should be theirs.
 /// When running under `sudo`, newly created files/dirs end up as root.
 /// This fixes that. No-op when not running as root.
+///
+/// Logging policy: routes through `tracing` (never direct stdio) because
+/// this can fire while the TUI owns the terminal — any `println!`/`eprintln!`
+/// here would scramble ratatui's rendering. Two failure paths:
+/// - `SUDO_UID` / `SUDO_GID` unset (vortix invoked as direct root, not via
+///   sudo): chown is structurally impossible, no operator action available,
+///   so we emit `tracing::debug!` only.
+/// - chown call itself failed (`EPERM`, broken filesystem, etc.): real
+///   failure the operator may want to know about — `tracing::warn!`.
 pub fn fix_ownership(path: &Path) {
     if !crate::utils::is_root() {
         return;
     }
     if let Err(e) = chown_to_real_user(path) {
-        eprintln!(
-            "Note: could not set ownership of {} to your user: {e}",
-            path.display()
-        );
+        if e.kind() == std::io::ErrorKind::NotFound {
+            // SUDO_UID/SUDO_GID unset — running as direct root. The chown
+            // is a no-op by design; nothing for the operator to act on.
+            tracing::debug!(
+                target: "vortix::config",
+                path = %path.display(),
+                "skipping chown: no SUDO_UID (direct-root invocation)"
+            );
+        } else {
+            tracing::warn!(
+                target: "vortix::config",
+                path = %path.display(),
+                err = %e,
+                "failed to chown to invoking user; files may remain root-owned"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`fix_ownership()` in `crates/vortix/src/config.rs:441` writes informational and warning messages directly to stderr via `eprintln!`. In TUI mode, ratatui owns the terminal's alternate screen — any direct stdio write scrambles rendering. The call fires up to 3× per `vortix up` (tmp dir, metadata.json, killswitch.json.tmp), so the corruption is immediate and reproducible.

Observed during the multi-distro manual testing for #218 on Fedora and Arch droplets — SSH as root, run `vortix up wg-split`, three `Note: could not set ownership of …` lines splat to stderr.

## What changes

Split the failure paths in `fix_ownership`:

- **`ErrorKind::NotFound`** (`SUDO_UID`/`SUDO_GID` env unset — direct-root invocation, no sudo): chown is structurally impossible; nothing for the operator to do → `tracing::debug!`.
- **Any other chown error** (`EPERM`, broken filesystem, etc.): real failure worth surfacing → `tracing::warn!` with the path + the `io::Error`.

Both route through the existing tracing infrastructure — file in TUI mode, stderr in CLI mode when `RUST_LOG` is set.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all green
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — clean
- [x] All four `cargo xtask check-*` boundary checks — clean
- [ ] Manual: SSH as direct root into a Linux client, `vortix up <profile>` — no `Note:` lines on stdout/stderr in CLI mode (debug-only via tracing); TUI rendering uncorrupted

## Notes

Narrow, contained fix — one function, ~20 added lines including doc comment. No behavior change beyond logging routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)