### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-12
+
+### Fixed
+
+- **`cargo install vortix` now compiles on a clean cargo cache.** The `time` crate published version `0.3.48` on the same day v0.4.0 shipped, and it carries a fresh `error[E0119]: conflicting implementations of trait From<...>` build break. Without `--locked`, cargo's resolver was happily picking the broken `time 0.3.48` for every user typing the canonical `cargo install vortix` command. Capped our workspace `time` dep at `<0.3.48` so the resolver can't reach the broken version; the lockfile already pinned the working `0.3.47`. Drop the cap once upstream releases a clean `0.3.49+`.
+
 ## [0.4.0] - 2026-06-11
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,7 +2868,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/vortix", "crates/xtask"]
 default-members = ["crates/vortix"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/vortix/CHANGELOG.md
+++ b/crates/vortix/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-12
+
+### Miscellaneous
+
+- Update Cargo.toml dependencies
+
+
+
 ## [0.4.0] - 2026-06-11
 
 ### Highlights

--- a/crates/vortix/CHANGELOG.md
+++ b/crates/vortix/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.4.1] - 2026-06-12
 
-### Miscellaneous
+### Fixed
 
-- Update Cargo.toml dependencies
+- **`cargo install vortix` now compiles on a clean cargo cache.** The `time` crate published version `0.3.48` on the same day v0.4.0 shipped, and it carries a fresh `error[E0119]: conflicting implementations of trait From<...>` build break. Without `--locked`, cargo's resolver was happily picking the broken `time 0.3.48` for every user typing the canonical `cargo install vortix` command. Capped our workspace `time` dep at `<0.3.48` so the resolver can't reach the broken version; the lockfile already pinned the working `0.3.47`. Drop the cap once upstream releases a clean `0.3.49+`.
 
 
 


### PR DESCRIPTION



## 🤖 New release

* `vortix`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1] - 2026-06-12

### Miscellaneous

- Update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).