### PR TITLE
chore: release v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,7 +2868,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortix"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/vortix", "crates/xtask"]
 default-members = ["crates/vortix"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/vortix/CHANGELOG.md
+++ b/crates/vortix/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-12
+
+### Miscellaneous
+
+- Update Cargo.toml dependencies
+
+
+
 ## [0.4.1] - 2026-06-12
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `vortix`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2] - 2026-06-12

### Miscellaneous

- Update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).