### PR TITLE
refactor(flip-panel): consume extracted ratatui-flip-panel crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,8 @@ dependencies = [
 [[package]]
 name = "ratatui-flip-panel"
 version = "0.1.0"
-source = "git+https://github.com/Harry-kp/ratatui-flip-panel.git?branch=main#a0f5abfd362017c9e051d2023639e0f23978984a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2539e91d41615fca6b61254a8e7e8348abd68eb9bbc244a466a30719d7a8b7"
 dependencies = [
  "ratatui-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-flip-panel"
+version = "0.1.0"
+source = "git+https://github.com/Harry-kp/ratatui-flip-panel.git?branch=main#a0f5abfd362017c9e051d2023639e0f23978984a"
+dependencies = [
+ "ratatui-core",
+]
+
+[[package]]
 name = "ratatui-macros"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,6 +2887,7 @@ dependencies = [
  "libc",
  "open",
  "ratatui",
+ "ratatui-flip-panel",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/vortix/Cargo.toml
+++ b/crates/vortix/Cargo.toml
@@ -44,6 +44,7 @@ path = "src/main.rs"
 # TUI Framework
 ratatui = { workspace = true }
 crossterm = { workspace = true }
+ratatui-flip-panel = { git = "https://github.com/Harry-kp/ratatui-flip-panel.git", branch = "main" }
 
 # Date/time formatting (local-offset needed for OffsetDateTime::now_local)
 time = { workspace = true }

--- a/crates/vortix/Cargo.toml
+++ b/crates/vortix/Cargo.toml
@@ -44,7 +44,7 @@ path = "src/main.rs"
 # TUI Framework
 ratatui = { workspace = true }
 crossterm = { workspace = true }
-ratatui-flip-panel = { git = "https://github.com/Harry-kp/ratatui-flip-panel.git", branch = "main" }
+ratatui-flip-panel = "0.1"
 
 # Date/time formatting (local-offset needed for OffsetDateTime::now_local)
 time = { workspace = true }

--- a/crates/vortix/src/app/connection.rs
+++ b/crates/vortix/src/app/connection.rs
@@ -412,8 +412,7 @@ impl App {
     pub(crate) fn complete_disconnect(&mut self, profile_name: &str) {
         self.runtime.session_start = None;
         self.runtime.scanner_rx = None; // discard stale scanner data pre-disconnect
-        self.panel_flipped.clear();
-        self.flip_animation = None;
+        self.flip_states.clear();
 
         self.runtime.public_ip = crate::constants::MSG_DETECTING.to_string();
         self.runtime.location = crate::constants::MSG_DETECTING.to_string();

--- a/crates/vortix/src/app/mod.rs
+++ b/crates/vortix/src/app/mod.rs
@@ -78,7 +78,7 @@ impl CachedConfigView {
         }
     }
 }
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::constants;
 use crate::logger;
@@ -89,8 +89,8 @@ use crate::vpn_runtime::VpnRuntime;
 
 // Re-export state types for convenient access
 pub use crate::state::{
-    AuthField, FlipAnimation, FocusedPanel, InputMode, ProfileSortOrder, Protocol, Toast,
-    ToastType, VpnProfile, DISMISS_DURATION,
+    AuthField, FlipState, FocusedPanel, InputMode, ProfileSortOrder, Protocol, Toast, ToastType,
+    VpnProfile, DISMISS_DURATION,
 };
 // The legacy single-tunnel `ConnectionState`/`DetailedConnectionInfo` enum
 // lives on `crate::vpn_runtime` after U6 Stage B; re-export through `app::`
@@ -134,8 +134,8 @@ pub struct App {
     // === UI State (Panel-based) ===
     pub focused_panel: FocusedPanel,
     pub zoomed_panel: Option<FocusedPanel>,
-    pub panel_flipped: HashSet<FocusedPanel>,
-    pub flip_animation: Option<FlipAnimation>,
+    /// Per-panel flip animation state (front/back card-flip via ratatui-flip-panel).
+    pub flip_states: HashMap<FocusedPanel, FlipState>,
     pub input_mode: InputMode,
     pub show_config: bool,
     pub show_action_menu: bool,
@@ -188,8 +188,7 @@ impl App {
 
             focused_panel: FocusedPanel::Sidebar,
             zoomed_panel: None,
-            panel_flipped: HashSet::new(),
-            flip_animation: None,
+            flip_states: HashMap::new(),
             input_mode: InputMode::Normal,
             show_config: false,
             show_action_menu: false,
@@ -272,44 +271,36 @@ impl App {
     }
 
     /// Check if a panel is currently showing its back (detailed) view.
+    /// Mid-animation aware: returns the post-midpoint face during a flip.
     #[must_use]
     pub fn is_flipped(&self, panel: &FocusedPanel) -> bool {
-        self.panel_flipped.contains(panel)
+        self.flip_states
+            .get(panel)
+            .is_some_and(FlipState::showing_back)
     }
 
-    /// Whether a flip animation is in progress.
+    /// Whether any panel is currently mid-flip.
     #[must_use]
     pub fn has_active_animation(&self) -> bool {
-        self.flip_animation.is_some()
+        self.flip_states.values().any(FlipState::is_animating)
     }
 
-    /// Advance the flip animation; finalize the state change when complete.
+    /// Drive every flip state machine forward one tick. Call once per frame.
     pub fn advance_animation(&mut self) {
-        let complete = self
-            .flip_animation
-            .as_ref()
-            .is_some_and(FlipAnimation::is_complete);
-        if complete {
-            if let Some(anim) = self.flip_animation.take() {
-                if anim.to_back {
-                    self.panel_flipped.insert(anim.panel);
-                } else {
-                    self.panel_flipped.remove(&anim.panel);
-                }
-            }
+        for state in self.flip_states.values_mut() {
+            state.tick();
         }
     }
 
-    /// Effective flip state for rendering, accounting for mid-animation view switch.
+    /// Effective flip state for rendering, accounting for mid-animation view swap.
     #[must_use]
     pub fn effective_flipped(&self, panel: &FocusedPanel) -> bool {
-        let base = self.is_flipped(panel);
-        if let Some(anim) = &self.flip_animation {
-            if anim.panel == *panel && anim.past_midpoint() {
-                return !base;
-            }
-        }
-        base
+        self.is_flipped(panel)
+    }
+
+    /// Borrow the flip state for `panel`, creating a default one if missing.
+    pub fn flip_state_mut(&mut self, panel: FocusedPanel) -> &mut FlipState {
+        self.flip_states.entry(panel).or_default()
     }
 }
 
@@ -342,8 +333,7 @@ impl App {
 
             focused_panel: FocusedPanel::Sidebar,
             zoomed_panel: None,
-            panel_flipped: HashSet::new(),
-            flip_animation: None,
+            flip_states: HashMap::new(),
             input_mode: InputMode::Normal,
             show_config: false,
             show_action_menu: false,

--- a/crates/vortix/src/app/tests.rs
+++ b/crates/vortix/src/app/tests.rs
@@ -34,8 +34,7 @@ fn test_app() -> App {
         log_level_filter: None,
         focused_panel: FocusedPanel::Sidebar,
         zoomed_panel: None,
-        panel_flipped: std::collections::HashSet::new(),
-        flip_animation: None,
+        flip_states: std::collections::HashMap::new(),
         input_mode: InputMode::Normal,
         show_config: false,
         show_action_menu: false,
@@ -2446,16 +2445,10 @@ fn rename_accepts_spaces_and_hyphens() {
 
 // === Flip Panel Tests ===
 
-/// Simulate completing a flip animation (advances time past the duration).
-fn complete_flip(app: &mut App) {
-    // Force-complete: take the animation and apply the state change
-    if let Some(anim) = app.flip_animation.take() {
-        if anim.to_back {
-            app.panel_flipped.insert(anim.panel);
-        } else {
-            app.panel_flipped.remove(&anim.panel);
-        }
-    }
+/// Simulate completing a flip by setting the showing-back state directly.
+fn complete_flip(app: &mut App, panel: FocusedPanel) {
+    let target = !app.is_flipped(&panel);
+    app.flip_state_mut(panel).set_showing_back(target);
 }
 
 #[test]
@@ -2463,7 +2456,7 @@ fn flip_starts_animation() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::Chart;
     app.handle_message(Message::ToggleFlip);
-    assert!(app.flip_animation.is_some());
+    assert!(app.has_active_animation());
     assert!(!app.is_flipped(&FocusedPanel::Chart));
 }
 
@@ -2473,10 +2466,10 @@ fn flip_toggles_chart_panel_after_animation() {
     app.focused_panel = FocusedPanel::Chart;
     assert!(!app.is_flipped(&FocusedPanel::Chart));
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
+    complete_flip(&mut app, FocusedPanel::Chart);
     assert!(app.is_flipped(&FocusedPanel::Chart));
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
+    complete_flip(&mut app, FocusedPanel::Chart);
     assert!(!app.is_flipped(&FocusedPanel::Chart));
 }
 
@@ -2485,7 +2478,7 @@ fn flip_toggles_security_panel() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::Security;
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
+    complete_flip(&mut app, FocusedPanel::Security);
     assert!(app.is_flipped(&FocusedPanel::Security));
     assert!(!app.is_flipped(&FocusedPanel::Chart));
 }
@@ -2495,7 +2488,7 @@ fn flip_toggles_connection_details_panel() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::ConnectionDetails;
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
+    complete_flip(&mut app, FocusedPanel::ConnectionDetails);
     assert!(app.is_flipped(&FocusedPanel::ConnectionDetails));
 }
 
@@ -2504,8 +2497,8 @@ fn flip_ignores_sidebar() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::Sidebar;
     app.handle_message(Message::ToggleFlip);
-    assert!(app.flip_animation.is_none());
-    assert!(app.panel_flipped.is_empty());
+    assert!(!app.has_active_animation());
+    assert!(app.flip_states.is_empty());
 }
 
 #[test]
@@ -2513,8 +2506,8 @@ fn flip_ignores_logs() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::Logs;
     app.handle_message(Message::ToggleFlip);
-    assert!(app.flip_animation.is_none());
-    assert!(app.panel_flipped.is_empty());
+    assert!(!app.has_active_animation());
+    assert!(app.flip_states.is_empty());
 }
 
 #[test]
@@ -2522,10 +2515,12 @@ fn flip_blocked_during_active_animation() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::Chart;
     app.handle_message(Message::ToggleFlip);
-    assert!(app.flip_animation.is_some());
-    let started = app.flip_animation.as_ref().unwrap().started;
+    assert!(app.has_active_animation());
+    // Second toggle while animating should be a no-op; the in-flight
+    // flip from the first toggle proceeds unchanged.
     app.handle_message(Message::ToggleFlip);
-    assert_eq!(app.flip_animation.as_ref().unwrap().started, started);
+    assert!(app.has_active_animation());
+    assert!(!app.is_flipped(&FocusedPanel::Chart));
 }
 
 #[test]
@@ -2533,7 +2528,7 @@ fn flip_state_persists_across_focus_changes() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::Chart;
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
+    complete_flip(&mut app, FocusedPanel::Chart);
     assert!(app.is_flipped(&FocusedPanel::Chart));
     app.focused_panel = FocusedPanel::Security;
     assert!(app.is_flipped(&FocusedPanel::Chart));
@@ -2544,10 +2539,10 @@ fn flip_multiple_panels_independently() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::Chart;
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
+    complete_flip(&mut app, FocusedPanel::Chart);
     app.focused_panel = FocusedPanel::Security;
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
+    complete_flip(&mut app, FocusedPanel::Security);
     assert!(app.is_flipped(&FocusedPanel::Chart));
     assert!(app.is_flipped(&FocusedPanel::Security));
     assert!(!app.is_flipped(&FocusedPanel::ConnectionDetails));
@@ -2559,6 +2554,7 @@ fn flip_effective_state_at_midpoint() {
     app.focused_panel = FocusedPanel::Chart;
     assert!(!app.effective_flipped(&FocusedPanel::Chart));
     app.handle_message(Message::ToggleFlip);
+    // Just-started animation hasn't passed the midpoint yet.
     assert!(!app.effective_flipped(&FocusedPanel::Chart));
 }
 
@@ -2570,50 +2566,40 @@ fn flip_state_cleared_on_disconnect() {
 
     app.focused_panel = FocusedPanel::Chart;
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
+    complete_flip(&mut app, FocusedPanel::Chart);
     app.focused_panel = FocusedPanel::Security;
     app.handle_message(Message::ToggleFlip);
-    complete_flip(&mut app);
-    assert_eq!(app.panel_flipped.len(), 2);
+    complete_flip(&mut app, FocusedPanel::Security);
+    assert_eq!(app.flip_states.len(), 2);
 
     app.complete_disconnect("test-profile");
-    assert!(app.panel_flipped.is_empty());
+    assert!(app.flip_states.is_empty());
 }
 
 #[test]
 fn advance_animation_completes_to_back() {
+    use std::time::Duration;
     let mut app = test_app();
-    app.flip_animation = Some(crate::state::FlipAnimation {
-        panel: FocusedPanel::Chart,
-        started: std::time::Instant::now()
-            .checked_sub(std::time::Duration::from_millis(
-                crate::constants::FLIP_ANIMATION_DURATION_MS + 10,
-            ))
-            .unwrap(),
-        to_back: true,
-    });
-    assert!(!app.is_flipped(&FocusedPanel::Chart));
+    let mut state = crate::state::FlipState::new(Duration::from_millis(20));
+    state.flip();
+    app.flip_states.insert(FocusedPanel::Chart, state);
+    std::thread::sleep(Duration::from_millis(80));
     app.advance_animation();
-    assert!(app.flip_animation.is_none());
+    assert!(!app.has_active_animation());
     assert!(app.is_flipped(&FocusedPanel::Chart));
 }
 
 #[test]
 fn advance_animation_completes_to_front() {
+    use std::time::Duration;
     let mut app = test_app();
-    app.panel_flipped.insert(FocusedPanel::Security);
-    app.flip_animation = Some(crate::state::FlipAnimation {
-        panel: FocusedPanel::Security,
-        started: std::time::Instant::now()
-            .checked_sub(std::time::Duration::from_millis(
-                crate::constants::FLIP_ANIMATION_DURATION_MS + 10,
-            ))
-            .unwrap(),
-        to_back: false,
-    });
-    assert!(app.is_flipped(&FocusedPanel::Security));
+    let mut state = crate::state::FlipState::new(Duration::from_millis(20));
+    state.set_showing_back(true);
+    state.flip();
+    app.flip_states.insert(FocusedPanel::Security, state);
+    std::thread::sleep(Duration::from_millis(80));
     app.advance_animation();
-    assert!(app.flip_animation.is_none());
+    assert!(!app.has_active_animation());
     assert!(!app.is_flipped(&FocusedPanel::Security));
 }
 
@@ -2622,23 +2608,19 @@ fn advance_animation_noop_when_still_running() {
     let mut app = test_app();
     app.focused_panel = FocusedPanel::Chart;
     app.handle_message(Message::ToggleFlip);
-    assert!(app.flip_animation.is_some());
+    assert!(app.has_active_animation());
     app.advance_animation();
-    assert!(app.flip_animation.is_some());
+    assert!(app.has_active_animation());
 }
 
 #[test]
 fn effective_flipped_shows_target_after_midpoint() {
+    use std::time::Duration;
     let mut app = test_app();
-    app.flip_animation = Some(crate::state::FlipAnimation {
-        panel: FocusedPanel::Chart,
-        started: std::time::Instant::now()
-            .checked_sub(std::time::Duration::from_millis(
-                crate::constants::FLIP_ANIMATION_DURATION_MS * 3 / 4,
-            ))
-            .unwrap(),
-        to_back: true,
-    });
+    let mut state = crate::state::FlipState::new(Duration::from_millis(100));
+    state.flip();
+    app.flip_states.insert(FocusedPanel::Chart, state);
+    std::thread::sleep(Duration::from_millis(75));
     assert!(app.effective_flipped(&FocusedPanel::Chart));
 }
 
@@ -2649,9 +2631,10 @@ fn disconnect_clears_animation() {
     set_connected(&mut app, "p1");
     app.focused_panel = FocusedPanel::Chart;
     app.handle_message(Message::ToggleFlip);
-    assert!(app.flip_animation.is_some());
+    assert!(app.has_active_animation());
     app.complete_disconnect("p1");
-    assert!(app.flip_animation.is_none());
+    assert!(!app.has_active_animation());
+    assert!(app.flip_states.is_empty());
 }
 
 // ====================================================================

--- a/crates/vortix/src/app/update.rs
+++ b/crates/vortix/src/app/update.rs
@@ -230,14 +230,8 @@ impl App {
                 if matches!(
                     panel,
                     FocusedPanel::Chart | FocusedPanel::ConnectionDetails | FocusedPanel::Security
-                ) && self.flip_animation.is_none()
-                {
-                    let to_back = !self.is_flipped(&panel);
-                    self.flip_animation = Some(crate::state::FlipAnimation {
-                        panel,
-                        started: std::time::Instant::now(),
-                        to_back,
-                    });
+                ) {
+                    self.flip_state_mut(panel).flip();
                 }
             }
             Message::CloseOverlay => {

--- a/crates/vortix/src/state/mod.rs
+++ b/crates/vortix/src/state/mod.rs
@@ -22,7 +22,6 @@ pub use killswitch::{KillSwitchMode, KillSwitchState};
 pub use profile::{Protocol, VpnProfile};
 pub use retry::RetryState;
 pub use ui::{
-    help_max_scroll_for_terminal_height, AuthField, FlipAnimation, FocusedPanel, HelpTab,
-    InputMode, ProfileSortOrder, QualityLevel, Toast, ToastType, DISMISS_DURATION,
-    HELP_OVERLAY_MAX_HEIGHT,
+    help_max_scroll_for_terminal_height, AuthField, FlipState, FocusedPanel, HelpTab, InputMode,
+    ProfileSortOrder, QualityLevel, Toast, ToastType, DISMISS_DURATION, HELP_OVERLAY_MAX_HEIGHT,
 };

--- a/crates/vortix/src/state/ui.rs
+++ b/crates/vortix/src/state/ui.rs
@@ -256,50 +256,7 @@ pub fn help_max_scroll_for_terminal_height(terminal_height: u16, total_lines: u1
     total_lines.saturating_sub(content_height)
 }
 
-/// State for the panel flip animation.
-pub struct FlipAnimation {
-    /// Which panel is being animated.
-    pub panel: FocusedPanel,
-    /// When the animation started.
-    pub started: Instant,
-    /// Whether flipping toward the back (true) or toward the front (false).
-    pub to_back: bool,
-}
-
-impl FlipAnimation {
-    /// Progress from 0.0 (start) to 1.0 (complete), clamped.
-    #[must_use]
-    #[allow(clippy::cast_precision_loss)]
-    pub fn progress(&self) -> f64 {
-        let elapsed_us = self.started.elapsed().as_micros().min(u128::from(u64::MAX)) as f64;
-        let duration_us = (crate::constants::FLIP_ANIMATION_DURATION_MS * 1000) as f64;
-        (elapsed_us / duration_us).min(1.0)
-    }
-
-    /// True when the animation has run its full duration.
-    #[must_use]
-    pub fn is_complete(&self) -> bool {
-        self.started.elapsed()
-            >= Duration::from_millis(crate::constants::FLIP_ANIMATION_DURATION_MS)
-    }
-
-    /// Width ratio for the current animation frame (1.0 → 0.0 → 1.0).
-    #[must_use]
-    pub fn width_ratio(&self) -> f64 {
-        let p = self.progress();
-        if p < 0.5 {
-            1.0 - (p * 2.0)
-        } else {
-            (p - 0.5) * 2.0
-        }
-    }
-
-    /// True when past the midpoint (showing the target view).
-    #[must_use]
-    pub fn past_midpoint(&self) -> bool {
-        self.progress() >= 0.5
-    }
-}
+pub use ratatui_flip_panel::FlipState;
 
 /// Profile list sort ordering.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -440,75 +397,5 @@ mod tests {
         assert_eq!(help_max_scroll_for_terminal_height(0, 44), 0);
     }
 
-    // --- FlipAnimation tests ---
-
-    fn make_animation(to_back: bool) -> FlipAnimation {
-        FlipAnimation {
-            panel: FocusedPanel::Chart,
-            started: Instant::now(),
-            to_back,
-        }
-    }
-
-    #[test]
-    fn animation_starts_not_complete() {
-        let anim = make_animation(true);
-        assert!(!anim.is_complete());
-        assert!(anim.progress() < 0.1);
-    }
-
-    #[test]
-    fn animation_width_ratio_starts_near_one() {
-        let anim = make_animation(true);
-        assert!(anim.width_ratio() > 0.8);
-    }
-
-    #[test]
-    fn animation_not_past_midpoint_at_start() {
-        let anim = make_animation(true);
-        assert!(!anim.past_midpoint());
-    }
-
-    #[test]
-    fn animation_complete_after_duration() {
-        let anim = FlipAnimation {
-            panel: FocusedPanel::Security,
-            started: Instant::now()
-                .checked_sub(Duration::from_millis(
-                    crate::constants::FLIP_ANIMATION_DURATION_MS + 10,
-                ))
-                .unwrap(),
-            to_back: false,
-        };
-        assert!(anim.is_complete());
-        assert!((anim.progress() - 1.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn animation_past_midpoint_after_duration() {
-        let anim = FlipAnimation {
-            panel: FocusedPanel::Chart,
-            started: Instant::now()
-                .checked_sub(Duration::from_millis(
-                    crate::constants::FLIP_ANIMATION_DURATION_MS,
-                ))
-                .unwrap(),
-            to_back: true,
-        };
-        assert!(anim.past_midpoint());
-    }
-
-    #[test]
-    fn animation_width_ratio_one_when_complete() {
-        let anim = FlipAnimation {
-            panel: FocusedPanel::ConnectionDetails,
-            started: Instant::now()
-                .checked_sub(Duration::from_millis(
-                    crate::constants::FLIP_ANIMATION_DURATION_MS + 50,
-                ))
-                .unwrap(),
-            to_back: true,
-        };
-        assert!((anim.width_ratio() - 1.0).abs() < f64::EPSILON);
-    }
+    // FlipState behavior is tested in the `ratatui-flip-panel` crate.
 }

--- a/crates/vortix/src/ui/dashboard/mod.rs
+++ b/crates/vortix/src/ui/dashboard/mod.rs
@@ -149,11 +149,11 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
 /// Compute a horizontally-narrowed rect for the card-flip animation.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn animated_rect(area: Rect, width_ratio: f64) -> Rect {
+fn animated_rect(area: Rect, width_ratio: f32) -> Rect {
     if area.width == 0 || area.height == 0 {
         return area;
     }
-    let mut new_width = (f64::from(area.width) * width_ratio).max(1.0) as u16;
+    let mut new_width = (f32::from(area.width) * width_ratio).max(1.0) as u16;
     if new_width > area.width {
         new_width = area.width;
     }
@@ -169,11 +169,10 @@ fn render_animated_panel(
     area: Rect,
     render_fn: impl FnOnce(&mut Frame, &App, Rect),
 ) {
-    if let Some(anim) = &app.flip_animation {
-        if anim.panel == *panel {
+    if let Some(state) = app.flip_states.get(panel) {
+        if state.is_animating() {
             frame.render_widget(Clear, area);
-            let ratio = anim.width_ratio();
-            let narrow = animated_rect(area, ratio);
+            let narrow = animated_rect(area, state.width_ratio());
             if narrow.width >= constants::FLIP_ANIMATION_MIN_WIDTH {
                 render_fn(frame, app, narrow);
             } else {


### PR DESCRIPTION
## Summary

Extracts the flip-panel animation widget out of vortix into its own crate at [Harry-kp/ratatui-flip-panel](https://github.com/Harry-kp/ratatui-flip-panel) and switches vortix to consume it via a git dependency.

## Why

- **Single source of truth** — no more dual maintenance of the widget in this repo + an extraction copy
- **Reusability** — the widget is generic ratatui code with no vortix-specific concepts; surfacing it as a separate crate lets the wider ratatui community use it (planned crates.io publish: `ratatui-flip-panel = "0.1"`)
- **Cleaner internal model** — App's flip state moves from `panel_flipped: HashSet<FocusedPanel> + flip_animation: Option<FlipAnimation>` (one anim at a time, global) to `flip_states: HashMap<FocusedPanel, FlipState>` (independent per panel)

## Dependency shape (transitional)

Until the crate ships to crates.io, vortix consumes it via git:

```toml
ratatui-flip-panel = { git = "https://github.com/Harry-kp/ratatui-flip-panel.git", branch = "main" }
```

`Cargo.lock` pins the SHA, so contributors and CI build the same code. Once the crate is published, this becomes `ratatui-flip-panel = "0.1"` in a follow-up.

## Behaviour

No user-visible change. Every flip animation (Chart, Connection Details, Security Guard) works exactly as before — same animation curve, same key bindings, same render output.

## Test plan

- [x] Full CI parity locally: `cargo fmt --all -- --check`, `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`, plus all four `cargo xtask check-*-leak` boundary checks
- [x] 808 unit tests + 37 integration + 51 + 7 + 6 + 1 across all crates — all green
- [ ] CI verifies the matrix (Ubuntu / macOS / Windows where applicable)
- [ ] Manual smoke: open Vortix TUI, press `Tab` to focus each animated panel, press `b` to flip — confirm the animation runs and the back face renders correctly