### PR TITLE
docs(readme): add X/Twitter handle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Rust](https://img.shields.io/badge/Rust-1.85+-orange?logo=rust)](https://www.rust-lang.org/)
 [![GitHub Stars](https://img.shields.io/github/stars/Harry-kp/vortix?style=social)](https://github.com/Harry-kp/vortix)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/Harry-kp?logo=github)](https://github.com/sponsors/Harry-kp)
+[![X (Twitter)](https://img.shields.io/badge/X-%40Harshitc007-000000?logo=x&logoColor=white)](https://x.com/Harshitc007)
 
 Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding.
 


### PR DESCRIPTION
Adds @Harshitc007 to the existing badge row so readers landing on the repo have a clear place to find the handle to tag when sharing about vortix.

Placement is next to GitHub Sponsors since both are social-adjacent (identity / follow-me / support-me all live together at the tail of the badge row).

Rendered:

\`\`\`
[X (Twitter) @Harshitc007]  ← new
\`\`\`

Not doing (deliberately):
- Follow-count style badge (`shields.io/twitter/follow/...`) — noisier, and the counter can be stale via shields caching.
- Extra socials (Bluesky, Mastodon) — one primary handle is easier to remember; can add later if audience shifts.
- "Share this" / "Follow for updates" prose block — the badge is enough; over-instructing readers to share reads awkward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)