### PR TITLE
fix(cli): lifecycle hardening — idempotent up, tracked-orphan filter, flock lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Use the right tool: if you only run one WireGuard tunnel and don't care about te
 - **Advanced Telemetry** — Real-time throughput, latency, **jitter**, and **packet loss**
 - **Geo-Location** — Instant detection of your exit IP's city and country
 - **Leak detection** — Monitors for IPv6 leaks and DNS leaks in real-time
-- **Kill Switch** — Platform-native firewall (PF on macOS; `iptables` or `nftables` on Linux). Three modes — **Off** (no firewall), **Block on drop** (engages only if the VPN drops unexpectedly), **VPN-only** (firewall stays engaged whether the VPN is up or down — closes the gap-between-drop-and-reconnect leak window). Multi-tunnel-aware: every active tunnel's interface is allow-listed
+- **Kill Switch** — Platform-native firewall (PF on macOS; `iptables` or `nftables` on Linux). Three modes — **Off** (no firewall), **Block on drop** (engages only if the VPN drops unexpectedly), **VPN-only** (firewall stays engaged whether the VPN is up or down — closes the gap-between-drop-and-reconnect leak window). Multi-tunnel-aware: every active tunnel's interface is allow-listed. Rules survive vortix restarts and crashes but not an OS reboot — re-arm after boot
 - **Session event journal** *(v0.3.0)* — JSONL event log per session under `${XDG_DATA_HOME}/vortix/sessions/`, 30-day retention; useful for diagnostics and scripting
 - **Per-process socket audit** *(v0.3.0)* — `vortix audit` answers "is this traffic actually routing through the tunnel?" with per-PID socket inventory; Linux + macOS supported
 - **Versioned structured output** *(v0.3.0)* — every `--json` envelope carries a `schema_version` field (currently `2`) so consumers can detect breaking changes instead of finding them at runtime
@@ -266,6 +266,12 @@ sudo vortix killswitch vpn-only
 vortix killswitch               # Show current mode + behaviour
 sudo vortix release-killswitch  # Emergency firewall release
 ```
+
+> **Reboot boundary:** kill-switch firewall rules live in the OS firewall
+> (PF / iptables / nftables), which is flushed on reboot. `vpn-only` mode is
+> therefore **not enforced between boot and the next vortix launch** — re-arm
+> it (`sudo vortix killswitch vpn-only`) after restarting. Rules do survive
+> vortix restarts, crashes, and binary upgrades within one boot.
 
 **System:**
 ```bash

--- a/crates/vortix/CHANGELOG.md
+++ b/crates/vortix/CHANGELOG.md
@@ -6,7 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **`vortix up` is now truly idempotent.** Re-running `up` for an already-connected profile prints `Already connected` and exits 0 instead of re-spawning the tunnel. Previously a second `up` of an OpenVPN profile spawned a duplicate daemon whose `--writepid` clobbered the first's pidfile, leaving the original daemon untracked.
+- **No more spurious orphan warnings for live tunnels.** The startup orphan scan now excludes PIDs recorded in profile pidfiles (`run/<name>.pid`), so `vortix down` / `status` no longer flags the active session's own `openvpn` daemon as a "possible orphan from a previous session."
+- **Concurrent `up`/`down`/`reconnect` invocations are serialized** via a `flock` lifecycle lock in the config dir. Two terminals racing the same mutation now queue instead of interleaving; the second prints a one-line "waiting…" note.
+- **OpenVPN double-spawn guard** at the tunnel layer: `up()` refuses when the profile's pidfile records a live daemon (covers the mid-negotiation window the scanner can't see).
 - WireGuard connect on a Linux host with IPv6 disabled no longer fails mid-way inside `wg-quick` with a raw `RTNETLINK answers: Operation not supported` dump ([#242](https://github.com/Harry-kp/vortix/issues/242)). When the profile's `Address` line declares an IPv6 entry but kernel IPv6 is off (sysctl `disable_ipv6=1` or `ipv6.disable=1` boot param), both the TUI and CLI now refuse pre-flight with an actionable message: re-enable IPv6 via sysctl, or remove the IPv6 entry from the profile. The profile is never rewritten silently.
+
+### Changed
+
+- README now documents the kill-switch **reboot boundary**: firewall rules do not survive an OS reboot, so `vpn-only` is unenforced between boot and the next vortix launch. (Persistence across reboot is tracked separately.)
 
 ## [0.4.2] - 2026-06-16
 

--- a/crates/vortix/src/cli/commands.rs
+++ b/crates/vortix/src/cli/commands.rs
@@ -341,6 +341,7 @@ fn handle_up(
     // registry conflict-check into the CLI path, this flag will gate
     // the bypass.
     let _ = yes;
+    let _lifecycle_lock = crate::utils::acquire_lifecycle_lock();
     let mut engine = VpnRuntime::new_headless(config.clone(), config_dir.to_path_buf());
 
     let profile_name = if let Some(name) = profile {
@@ -410,6 +411,38 @@ fn handle_up(
                 ExitCode::GeneralError,
             );
         }
+    }
+
+    // True idempotency: `up` of an already-connected profile is a
+    // success no-op, mirroring `down`'s already-disconnected path.
+    // Without this, a second `up` re-spawned the tunnel — for OpenVPN
+    // that meant a duplicate daemon whose pidfile clobbered the first's.
+    if crate::core::scanner::get_active_profiles(&engine.profiles)
+        .iter()
+        .any(|s| s.name == profile_name)
+    {
+        let protocol = engine
+            .profiles
+            .iter()
+            .find(|p| p.name == profile_name)
+            .map_or_else(|| "VPN".to_string(), |p| p.protocol.to_string());
+        let data = UpData {
+            state: "connected".into(),
+            profile: profile_name.clone(),
+            protocol: protocol.clone(),
+        };
+        let next = vec![
+            "vortix status --json".into(),
+            "sudo vortix down --json".to_string(),
+        ];
+        match mode {
+            OutputMode::Human => {
+                println!("● Already connected to {profile_name} ({protocol})");
+            }
+            OutputMode::Json => print_success(mode, "up", &data, next),
+            OutputMode::Quiet => {}
+        }
+        return 0;
     }
 
     // Multi-connection plan #001 U7: route the CLI connect through the
@@ -698,6 +731,7 @@ fn handle_down(
     mode: OutputMode,
 ) -> i32 {
     let _ = all; // `--all` is the explicit form of the no-profile case (already the default).
+    let _lifecycle_lock = crate::utils::acquire_lifecycle_lock();
     let mut engine = VpnRuntime::new_headless(config.clone(), config_dir.to_path_buf());
 
     // NotFound (exit 3) takes precedence over idempotence: a typo'd
@@ -807,6 +841,7 @@ fn handle_reconnect(
     config_dir: &Path,
     mode: OutputMode,
 ) -> i32 {
+    let _lifecycle_lock = crate::utils::acquire_lifecycle_lock();
     let mut engine = VpnRuntime::new_headless(config.clone(), config_dir.to_path_buf());
     engine.load_metadata();
 

--- a/crates/vortix/src/cli/commands.rs
+++ b/crates/vortix/src/cli/commands.rs
@@ -341,7 +341,7 @@ fn handle_up(
     // registry conflict-check into the CLI path, this flag will gate
     // the bypass.
     let _ = yes;
-    let _lifecycle_lock = crate::utils::acquire_lifecycle_lock();
+    let _lifecycle_lock = acquire_lifecycle_lock_or_exit(mode, "up");
     let mut engine = VpnRuntime::new_headless(config.clone(), config_dir.to_path_buf());
 
     let profile_name = if let Some(name) = profile {
@@ -666,6 +666,25 @@ fn handle_up(
 /// same set of takeovers. The route-overlap branch is a CLI-only
 /// superset until R10 v2 brings route-overlap detection into the
 /// registry.
+/// Acquire the cross-process lifecycle lock or exit with a structured
+/// error. Proceeding without the lock would reintroduce the concurrent
+/// `up`/`down` interleaving the lock exists to prevent.
+fn acquire_lifecycle_lock_or_exit(mode: OutputMode, command: &str) -> std::fs::File {
+    match crate::utils::acquire_lifecycle_lock() {
+        Ok(file) => file,
+        Err(e) => print_error_and_exit(
+            mode,
+            command,
+            CliError {
+                code: "lock_failed",
+                message: format!("Could not acquire the vortix lifecycle lock: {e}"),
+                hint: Some("Check permissions on the vortix config directory.".into()),
+            },
+            ExitCode::GeneralError,
+        ),
+    }
+}
+
 fn detect_conflict_for_cli(
     engine: &VpnRuntime,
     target_name: &str,
@@ -731,7 +750,7 @@ fn handle_down(
     mode: OutputMode,
 ) -> i32 {
     let _ = all; // `--all` is the explicit form of the no-profile case (already the default).
-    let _lifecycle_lock = crate::utils::acquire_lifecycle_lock();
+    let _lifecycle_lock = acquire_lifecycle_lock_or_exit(mode, "down");
     let mut engine = VpnRuntime::new_headless(config.clone(), config_dir.to_path_buf());
 
     // NotFound (exit 3) takes precedence over idempotence: a typo'd
@@ -841,7 +860,7 @@ fn handle_reconnect(
     config_dir: &Path,
     mode: OutputMode,
 ) -> i32 {
-    let _lifecycle_lock = crate::utils::acquire_lifecycle_lock();
+    let _lifecycle_lock = acquire_lifecycle_lock_or_exit(mode, "reconnect");
     let mut engine = VpnRuntime::new_headless(config.clone(), config_dir.to_path_buf());
     engine.load_metadata();
 

--- a/crates/vortix/src/main.rs
+++ b/crates/vortix/src/main.rs
@@ -173,7 +173,18 @@ fn main() -> Result<()> {
     // `wireguard-go` daemon is probably still running. Warn so they
     // know to clean up (no auto-adopt — adoption arrives with the
     // plan 010 IPC layer).
-    let orphans = vortix::vortix_process::scan_orphans();
+    //
+    // PIDs recorded in a profile's `run/<name>.pid` belong to a tracked
+    // session (openvpn daemons reparent to init, so the bare scan can't
+    // tell "mine" from "leftover") — exclude them from the warning.
+    let tracked_pids: Vec<u32> = vortix::vpn::load_profiles()
+        .iter()
+        .filter_map(|p| vortix::utils::read_openvpn_pid(&p.name))
+        .collect();
+    let orphans = vortix::vortix_process::filter_untracked(
+        vortix::vortix_process::scan_orphans(),
+        &tracked_pids,
+    );
     if !orphans.is_empty() {
         eprintln!(
             "Warning: detected {} possible orphan VPN process(es) from a previous session:",

--- a/crates/vortix/src/main.rs
+++ b/crates/vortix/src/main.rs
@@ -174,13 +174,11 @@ fn main() -> Result<()> {
     // know to clean up (no auto-adopt — adoption arrives with the
     // plan 010 IPC layer).
     //
-    // PIDs recorded in a profile's `run/<name>.pid` belong to a tracked
-    // session (openvpn daemons reparent to init, so the bare scan can't
-    // tell "mine" from "leftover") — exclude them from the warning.
-    let tracked_pids: Vec<u32> = vortix::vpn::load_profiles()
-        .iter()
-        .filter_map(|p| vortix::utils::read_openvpn_pid(&p.name))
-        .collect();
+    // PIDs recorded in `run/*.pid` belong to a tracked session (openvpn
+    // daemons reparent to init, so the bare scan can't tell "mine" from
+    // "leftover") — exclude them from the warning. Reads only the run
+    // dir; profile files are never parsed here.
+    let tracked_pids = vortix::utils::tracked_openvpn_pids();
     let orphans = vortix::vortix_process::filter_untracked(
         vortix::vortix_process::scan_orphans(),
         &tracked_pids,

--- a/crates/vortix/src/utils.rs
+++ b/crates/vortix/src/utils.rs
@@ -1036,6 +1036,53 @@ pub(crate) fn host_ipv6_disabled() -> bool {
     })
 }
 
+/// Serialize tunnel lifecycle mutations (`up` / `down` / `reconnect`)
+/// across concurrent vortix processes via `flock` on a lockfile in the
+/// config dir. Without it, two `vortix up` invocations of the same
+/// `OpenVPN` profile both spawn daemons and the second clobbers the
+/// first's pidfile, orphaning it.
+///
+/// The lock is held for the returned `File`'s lifetime and released by
+/// the OS on process exit — safe across `std::process::exit` paths.
+/// Blocks (with a stderr note) when another invocation holds the lock.
+#[cfg(unix)]
+pub fn acquire_lifecycle_lock() -> std::io::Result<std::fs::File> {
+    use std::os::unix::io::AsRawFd;
+
+    let root = get_app_config_dir()?;
+    let path = root.join("lifecycle.lock");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)?;
+
+    // SAFETY: flock is a thin syscall wrapper over a valid owned fd; no
+    // buffers, no aliasing. Same invariant analysis as libc::kill in the
+    // OpenVPN teardown path.
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        eprintln!("Another vortix lifecycle operation is in progress — waiting…");
+        #[allow(unsafe_code)]
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+pub fn acquire_lifecycle_lock() -> std::io::Result<std::fs::File> {
+    let root = get_app_config_dir()?;
+    std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(root.join("lifecycle.lock"))
+}
+
 /// Check whether a `WireGuard` config declares an IPv6 entry on an
 /// `Address =` line. `wg-quick` runs `ip -6 address add` for each such
 /// entry, which fails outright when the kernel has IPv6 disabled

--- a/crates/vortix/src/utils.rs
+++ b/crates/vortix/src/utils.rs
@@ -253,6 +253,26 @@ pub fn get_openvpn_run_paths(
     Ok((pid_path, log_path))
 }
 
+/// PIDs recorded in `<config_dir>/run/*.pid` — the `OpenVPN` daemons a
+/// vortix session is tracking. Reads only the run dir (no profile
+/// parsing), so it's cheap enough for the startup orphan scan.
+#[must_use]
+pub fn tracked_openvpn_pids() -> Vec<u32> {
+    let Ok(root) = get_app_config_dir() else {
+        return Vec::new();
+    };
+    let run_dir = root.join(crate::constants::OPENVPN_RUN_DIR);
+    let Ok(entries) = std::fs::read_dir(run_dir) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "pid"))
+        .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+        .filter_map(|content| content.trim().parse::<u32>().ok())
+        .collect()
+}
+
 /// Cleans up `OpenVPN` runtime files (pid, log) for a given profile.
 pub fn cleanup_openvpn_run_files(profile_name: &str) {
     if let Ok((pid_path, log_path)) = get_openvpn_run_paths(profile_name) {
@@ -1045,6 +1065,10 @@ pub(crate) fn host_ipv6_disabled() -> bool {
 /// The lock is held for the returned `File`'s lifetime and released by
 /// the OS on process exit — safe across `std::process::exit` paths.
 /// Blocks (with a stderr note) when another invocation holds the lock.
+///
+/// Unix-only mutual exclusion: the non-Unix build opens the lockfile
+/// without locking (a placeholder — vortix tunnels are unsupported on
+/// Windows, so there is no lifecycle to serialize there yet).
 #[cfg(unix)]
 pub fn acquire_lifecycle_lock() -> std::io::Result<std::fs::File> {
     use std::os::unix::io::AsRawFd;

--- a/crates/vortix/src/vortix_process/mod.rs
+++ b/crates/vortix/src/vortix_process/mod.rs
@@ -13,7 +13,7 @@ pub mod orphan_scan;
 pub mod real;
 
 pub use mock::MockRunner;
-pub use orphan_scan::{scan_orphans, OrphanProcess};
+pub use orphan_scan::{filter_untracked, scan_orphans, OrphanProcess};
 pub use real::RealRunner;
 
 // Re-export the port types so callers don't have to depend on vortix-core directly

--- a/crates/vortix/src/vortix_process/orphan_scan.rs
+++ b/crates/vortix/src/vortix_process/orphan_scan.rs
@@ -56,6 +56,19 @@ pub fn scan_orphans() -> Vec<OrphanProcess> {
     parse_ps_output(&stdout)
 }
 
+/// Drop scanned processes whose PID is tracked by a live vortix session
+/// (e.g. an `openvpn --daemon` recorded in a profile's `run/<name>.pid`).
+/// Without this filter every vortix invocation flags its own active
+/// tunnel as an orphan — the daemon reparents to init, so a bare process
+/// scan cannot tell "mine" from "leftover".
+#[must_use]
+pub fn filter_untracked(orphans: Vec<OrphanProcess>, tracked_pids: &[u32]) -> Vec<OrphanProcess> {
+    orphans
+        .into_iter()
+        .filter(|o| !tracked_pids.contains(&o.pid))
+        .collect()
+}
+
 fn parse_ps_output(stdout: &str) -> Vec<OrphanProcess> {
     let mut out = Vec::new();
     for line in stdout.lines() {
@@ -163,5 +176,30 @@ mod tests {
         // ps returned an error, etc.). The test's job is to lock in
         // the no-panic contract that main.rs depends on.
         let _ = scan_orphans();
+    }
+
+    fn orphan(pid: u32) -> OrphanProcess {
+        OrphanProcess {
+            pid,
+            command: "openvpn".into(),
+        }
+    }
+
+    #[test]
+    fn filter_untracked_drops_tracked_pids() {
+        let got = filter_untracked(vec![orphan(100), orphan(200), orphan(300)], &[200]);
+        assert_eq!(got, vec![orphan(100), orphan(300)]);
+    }
+
+    #[test]
+    fn filter_untracked_keeps_all_when_nothing_tracked() {
+        let got = filter_untracked(vec![orphan(100)], &[]);
+        assert_eq!(got, vec![orphan(100)]);
+    }
+
+    #[test]
+    fn filter_untracked_empty_when_all_tracked() {
+        let got = filter_untracked(vec![orphan(100), orphan(200)], &[100, 200]);
+        assert_eq!(got, Vec::new());
     }
 }

--- a/crates/vortix/src/vortix_protocol_openvpn/tunnel.rs
+++ b/crates/vortix/src/vortix_protocol_openvpn/tunnel.rs
@@ -596,13 +596,22 @@ impl Tunnel for OvpnTunnel {
         // spawn would orphan it (--writepid last-write-wins clobbers the
         // record `down` uses for teardown). Dead-pid files fall through to
         // the stale cleanup below.
+        #[cfg(unix)]
         if let Ok(content) = std::fs::read_to_string(&pid_path) {
-            if let Ok(existing_pid) = content.trim().parse::<u32>() {
-                let alive = crate::vortix_process::run_to_output(CommandSpec::oneshot(
-                    "kill",
-                    vec!["-0".into(), existing_pid.to_string()],
-                ))
-                .is_ok_and(|o| o.status.success());
+            if let Some(existing_pid) = content
+                .trim()
+                .parse::<u32>()
+                .ok()
+                .and_then(|p| libc::pid_t::try_from(p).ok())
+            {
+                // SAFETY: kill(pid, 0) is a pure existence probe — no signal
+                // delivered, no buffers. Same invariant analysis as the
+                // SIGTERM teardown below. EPERM means the process exists but
+                // is owned elsewhere — treat as alive (refuse the spawn).
+                #[allow(unsafe_code)]
+                let rc = unsafe { libc::kill(existing_pid, 0) };
+                let alive =
+                    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
                 if alive {
                     return Err(TunnelError::Subprocess(format!(
                         "OpenVPN for '{}' is already running (pid {existing_pid}) — \

--- a/crates/vortix/src/vortix_protocol_openvpn/tunnel.rs
+++ b/crates/vortix/src/vortix_protocol_openvpn/tunnel.rs
@@ -591,6 +591,28 @@ impl Tunnel for OvpnTunnel {
         if let Some(parent) = pid_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+
+        // Refuse double-up: if the pidfile records a live daemon, a second
+        // spawn would orphan it (--writepid last-write-wins clobbers the
+        // record `down` uses for teardown). Dead-pid files fall through to
+        // the stale cleanup below.
+        if let Ok(content) = std::fs::read_to_string(&pid_path) {
+            if let Ok(existing_pid) = content.trim().parse::<u32>() {
+                let alive = crate::vortix_process::run_to_output(CommandSpec::oneshot(
+                    "kill",
+                    vec!["-0".into(), existing_pid.to_string()],
+                ))
+                .is_ok_and(|o| o.status.success());
+                if alive {
+                    return Err(TunnelError::Subprocess(format!(
+                        "OpenVPN for '{}' is already running (pid {existing_pid}) — \
+                         disconnect it first with `vortix down`",
+                        profile.display_name
+                    )));
+                }
+            }
+        }
+
         // Stale-file cleanup from any previous run.
         let _ = std::fs::remove_file(&pid_path);
         let _ = std::fs::remove_file(&log_path);


### PR DESCRIPTION
## Summary

Tier-1 + Tier-2 fixes from the CLI-lifecycle investigation triggered by the spurious orphan warning observed while testing #242 (`vortix down` flagged its own active openvpn daemon as a "possible orphan from a previous session" on every disconnect).

Root context: VPN daemons deliberately outlive the CLI (openvpn reparents to init; WG lives in the kernel), and no long-lived process owns them. These fixes harden the sharpest edges of that model **without** architectural change — the durable fix (daemon owns tunnels, TUI/CLI as thin clients) is tracked in #234.

## Fixes

| # | Fix | Where |
|---|---|---|
| 1 | **`vortix up` truly idempotent** — re-up of a connected profile → `Already connected`, exit 0, no re-spawn. Previously a second OpenVPN `up` spawned a duplicate daemon whose `--writepid` clobbered the first's pidfile, orphaning it. | `cli/commands.rs::handle_up` |
| 2 | **Orphan scan excludes tracked PIDs** — pids recorded in profile `run/<name>.pid` files are filtered before warning. New pure helper `vortix_process::filter_untracked` + 3 unit tests. Kills the false warning on every `down`. | `main.rs`, `vortix_process/orphan_scan.rs` |
| 3 | **`flock` lifecycle lock** (`<config_dir>/lifecycle.lock`) serializes concurrent `up`/`down`/`reconnect` across terminals. Second invocation prints "waiting…" and queues. Held for process lifetime; OS releases on exit (safe across `process::exit`). | `utils.rs`, wired into all 3 mutating handlers |
| 4 | **OpenVPN double-spawn guard** — `OvpnTunnel::up` refuses when the pidfile records a live daemon. Covers the mid-negotiation window where the scanner can't yet see the tunnel (defense-in-depth under fix 1). | `vortix_protocol_openvpn/tunnel.rs` |

## Docs (Tier 2)

- **README: kill-switch reboot boundary.** PF/iptables/nftables rules are flushed on reboot, so `vpn-only` is silently unenforced between boot and the next vortix launch — the README now states this honestly (feature bullet + a callout in the Security commands section). The actual boot-persistence fix is a separate issue.

## Not in this PR (deliberate)

- TUI-vs-CLI mutation race (the lock covers CLI↔CLI; TUI connect path uses its own flow) — daemon-shaped, see #234.
- Kill-switch boot persistence (pf anchor / systemd unit) — filed separately.
- Sleep/wake, wifi-switch, CLI reconnect-supervision — all daemon-shaped, see #234.

## Test plan

- [x] 822 tests pass (`cargo test --workspace`) — 3 new `filter_untracked` cases
- [x] clippy `--workspace --all-targets -D warnings`, rustdoc, fmt, all 4 xtask boundary checks
- [x] Manual: connect OpenVPN profile, `vortix down` → **no orphan warning**
- [x] Manual: `vortix up X` twice → second prints `Already connected`, exit 0, exactly one openvpn process
- [x] Manual: `up` in two terminals simultaneously → second waits, then no-ops as already-connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)