### PR TITLE
ci: auto-inject CHANGELOG notes into GitHub release body

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,81 @@
+name: Release Notes
+
+# cargo-dist creates the GitHub release with an install/download body only —
+# its changelog auto-detection doesn't reliably extract our keep-a-changelog
+# sections, so release pages shipped without notes (v0.4.2, v0.4.3 fixed by
+# hand). This workflow prepends the matching CHANGELOG.md section as
+# "## Release Notes" once the release is published, preserving dist's install
+# block below a separator. It lives in its own file so `dist generate` never
+# clobbers it (unlike release.yml).
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  inject-notes:
+    name: Inject changelog into release body
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepend changelog section to release body
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+          EXISTING_BODY: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+
+          # Idempotency: if notes are already present (manual fix, or a
+          # re-run), do nothing.
+          case "$EXISTING_BODY" in
+            *"## Release Notes"*)
+              echo "Release body already has notes; nothing to do."
+              exit 0
+              ;;
+          esac
+
+          # Tag "v0.4.3" -> changelog version "0.4.3".
+          VERSION="${TAG#v}"
+
+          CHANGELOG="crates/vortix/CHANGELOG.md"
+          if [ ! -f "$CHANGELOG" ]; then
+            echo "No $CHANGELOG found; skipping." >&2
+            exit 0
+          fi
+
+          # Extract the section between "## [<version>]" and the next
+          # "## [" heading, dropping the version heading line itself
+          # (the release page already shows the version).
+          SECTION="$(awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { grab = 1; next }
+            grab && /^## \[/ { exit }
+            grab { print }
+          ' "$CHANGELOG" | sed '/^[[:space:]]*$/{ /./d }' )"
+
+          # Trim leading/trailing blank lines.
+          SECTION="$(printf '%s\n' "$SECTION" | sed -e '/./,$!d' | sed -e ':a' -e '/^\n*$/{$d;N;ba}')"
+
+          if [ -z "$SECTION" ]; then
+            echo "No changelog section for $VERSION; leaving body unchanged." >&2
+            exit 0
+          fi
+
+          BODYFILE="$(mktemp)"
+          {
+            echo "## Release Notes"
+            echo
+            printf '%s\n' "$SECTION"
+            echo
+            echo "---"
+            echo
+            printf '%s\n' "$EXISTING_BODY"
+          } > "$BODYFILE"
+
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$BODYFILE"
+          echo "Injected notes for $TAG."


### PR DESCRIPTION
## Summary

Release pages have been shipping **without release notes** — v0.4.2 and v0.4.3 both showed only cargo-dist's install/download block, and I patched both by hand. This automates the fix.

**Why not release-plz config:** `release-plz.toml` sets `git_release_enable = false` — release-plz doesn't create the GitHub release, **cargo-dist does** (via `gh release create --notes-file` using its generated `announcement_github_body`). dist's changelog auto-detection doesn't reliably extract our keep-a-changelog sections (the `## [Unreleased]` + dated-heading layout), so the body comes out install-block-only.

**Why not edit `release.yml`:** that file is generated by `dist generate` and would clobber any hand-edit on the next dist bump.

**The fix:** a separate workflow (`release-notes.yml`) that fires on `release: published`, extracts the tag's `CHANGELOG.md` section, and prepends it as `## Release Notes` above dist's install block (separated by `---`).

## Properties

- **Idempotent** — skips if the body already contains `## Release Notes` (so a manual fix or a re-run is a no-op).
- **Regeneration-safe** — separate file, never touched by `dist generate`.
- **Injection-safe** — `tag_name` / `body` come through `env:` and are referenced as quoted shell vars, only ever written to a file, never evaluated (per the Actions injection guidance).
- Verified the awk extraction against the real changelog: pulls the full version section, stops at the previous version heading.

## Test plan

- [x] YAML validates; awk extraction produces the correct v0.4.3 section locally
- [ ] Live: next release (v0.5.0 / next patch) publishes → workflow prepends notes automatically. Until then, v0.4.2/v0.4.3 are already hand-fixed.

Note: this can't retroactively fire for v0.4.3 (already published + hand-fixed); it takes effect from the next release. If you want, I can trigger it once manually against v0.4.3 to confirm the end-to-end path — it'll no-op since notes are already present, proving the idempotency guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)