### PR TITLE
fix(tui): complete disconnects on kernel confirmation — close the teardown re-adopt window

### DIFF
--- a/crates/vortix/src/app/tests.rs
+++ b/crates/vortix/src/app/tests.rs
@@ -120,6 +120,13 @@ fn test_disconnect_result_success_transitions_to_disconnected() {
         error: None,
     });
 
+    // Completion is kernel-confirmed: the next scan reports the
+    // session gone, which finishes the disconnect.
+    app.handle_message(Message::SyncSystemState {
+        sessions: vec![],
+        default_route_interface: None,
+    });
+
     assert!(
         matches!(app.legacy_state(), ConnectionState::Disconnected),
         "Expected Disconnected after successful DisconnectResult"
@@ -602,11 +609,18 @@ fn switch_path_disconnect_completion_removes_old_profile_from_registry() {
         "setup precondition"
     );
 
-    // Worker thread reports vpn-a's disconnect completed.
+    // Worker thread reports vpn-a's disconnect completed; the next
+    // scan confirms the kernel session is gone.
     app.handle_message(Message::DisconnectResult {
         profile: "vpn-a".to_string(),
         success: true,
         error: None,
+    });
+    // Completion is kernel-confirmed: the next scan reports the
+    // session gone, which finishes the disconnect.
+    app.handle_message(Message::SyncSystemState {
+        sessions: vec![],
+        default_route_interface: None,
     });
 
     // vpn-a must be gone from the registry — the switch flow drained
@@ -697,6 +711,13 @@ fn test_pending_connect_drained_on_disconnect_success() {
         profile: "vpn-a".to_string(),
         success: true,
         error: None,
+    });
+
+    // Completion is kernel-confirmed: the next scan reports the
+    // session gone, which finishes the disconnect.
+    app.handle_message(Message::SyncSystemState {
+        sessions: vec![],
+        default_route_interface: None,
     });
 
     assert_eq!(app.runtime.pending_connect, None);
@@ -906,6 +927,13 @@ fn test_reconnect_auto_connects_after_disconnect_completes() {
         profile: "test-vpn".to_string(),
         success: true,
         error: None,
+    });
+
+    // Completion is kernel-confirmed: the next scan reports the
+    // session gone, which finishes the disconnect.
+    app.handle_message(Message::SyncSystemState {
+        sessions: vec![],
+        default_route_interface: None,
     });
 
     assert_eq!(app.runtime.pending_connect, None);
@@ -3387,6 +3415,12 @@ fn disconnect_result_success_removes_from_registry() {
         success: true,
         error: None,
     });
+    // Completion is kernel-confirmed: the next scan reports the
+    // session gone, which finishes the disconnect.
+    app.handle_message(Message::SyncSystemState {
+        sessions: vec![],
+        default_route_interface: None,
+    });
 
     assert_eq!(
         app.registry.tunnel_count(),
@@ -3863,4 +3897,58 @@ fn real_ip_frozen_once_connected_then_thaws_on_disconnect() {
         Some("198.51.100.99"),
         "real_ip must thaw and update after clean disconnect"
     );
+}
+
+#[test]
+fn disconnect_result_defers_completion_until_kernel_confirms() {
+    // Regression for the disconnect→reconnect loop: after `down()`
+    // reports success the VPN process can stay alive for another
+    // moment. Completing the disconnect on the worker's word removed
+    // the registry entry early; a scan captured in that window
+    // re-adopted the dying tunnel, its exit then read as an unexpected
+    // drop, and auto-reconnect resurrected the connection — making
+    // disconnect impossible. Completion must wait for the kernel.
+    let mut app = test_app();
+    add_profiles(&mut app, &["vpn-a"]);
+    set_connected(&mut app, "vpn-a");
+    app.mirror_disconnecting_into_registry("vpn-a");
+
+    // Worker reports success while the kernel session is still visible:
+    // the entry must stay Disconnecting.
+    app.handle_message(Message::DisconnectResult {
+        profile: "vpn-a".to_string(),
+        success: true,
+        error: None,
+    });
+    let id = crate::vortix_core::profile::ProfileId::new("vpn-a");
+    let snap = app.registry.snapshot(&id).expect("entry kept");
+    assert!(matches!(
+        snap.state,
+        crate::vortix_core::engine::state::Connection::Disconnecting { .. }
+    ));
+
+    // A stale scan still lists the dying session: no re-adoption, no drop.
+    app.handle_message(Message::SyncSystemState {
+        sessions: vec![fake_session("vpn-a")],
+        default_route_interface: None,
+    });
+    let snap = app.registry.snapshot(&id).expect("still tracked");
+    assert!(
+        matches!(
+            snap.state,
+            crate::vortix_core::engine::state::Connection::Disconnecting { .. }
+        ),
+        "a scan captured mid-teardown must not re-adopt the tunnel"
+    );
+    assert_eq!(app.runtime.connection_drops, 0);
+
+    // Kernel confirms the session is gone: disconnect completes, the
+    // exit is NOT an unexpected drop, and no auto-reconnect is queued.
+    app.handle_message(Message::SyncSystemState {
+        sessions: vec![],
+        default_route_interface: None,
+    });
+    assert!(app.registry.snapshot(&id).is_none());
+    assert_eq!(app.runtime.connection_drops, 0);
+    assert!(app.runtime.retry_state.is_empty());
 }

--- a/crates/vortix/src/app/update.rs
+++ b/crates/vortix/src/app/update.rs
@@ -474,7 +474,24 @@ impl App {
             // Still clean up files — the disconnect thread likely did kill the process
             utils::cleanup_openvpn_run_files(&profile);
         } else if success {
-            self.complete_disconnect(&profile);
+            // The worker's exit status is not kernel truth: openvpn can
+            // take another second or two to die after `down()` returns.
+            // Completing the disconnect here removes the registry entry
+            // while the kernel session is still visible, which reopens
+            // the adoption window — the next scanner tick re-adopts the
+            // dying process as an "externally started" tunnel, the tick
+            // after that reads its exit as an unexpected drop, and
+            // auto-reconnect resurrects the connection the user just
+            // tore down (an unbreakable disconnect→reconnect loop).
+            // Keep the entry Disconnecting; the scanner completes the
+            // disconnect via its `(Disconnecting, None)` arm the moment
+            // the kernel confirms the session is gone, which also runs
+            // the pending-connect drain and kill-switch sync exactly
+            // once. The disconnect-timeout arm still catches teardowns
+            // that never converge.
+            self.log(&format!(
+                "STATUS: Teardown finished for '{profile}' — awaiting kernel confirmation"
+            ));
         } else {
             let err_msg = error.unwrap_or_else(|| "unknown error".to_string());
             self.log(&format!("ERR: Failed to disconnect '{profile}': {err_msg}"));

--- a/crates/vortix/tests/integration.rs
+++ b/crates/vortix/tests/integration.rs
@@ -215,6 +215,13 @@ mod connection_state_machine {
             success: true,
             error: None,
         });
+        // Completion is kernel-confirmed: the worker's success keeps the
+        // entry Disconnecting; the next scan reporting the session gone
+        // finishes the disconnect (guards the re-adopt/reconnect loop).
+        app.handle_message(Message::SyncSystemState {
+            sessions: vec![],
+            default_route_interface: None,
+        });
         assert!(matches!(app.legacy_state(), ConnectionState::Disconnected));
     }
 
@@ -318,11 +325,18 @@ mod connection_state_machine {
             ConnectionState::Disconnecting { .. }
         ));
 
-        // Disconnecting -> Disconnected
+        // Disconnecting -> Disconnected (kernel-confirmed)
         app.handle_message(Message::DisconnectResult {
             profile: "vpn-a".to_string(),
             success: true,
             error: None,
+        });
+        // Completion is kernel-confirmed: the worker's success keeps the
+        // entry Disconnecting; the next scan reporting the session gone
+        // finishes the disconnect (guards the re-adopt/reconnect loop).
+        app.handle_message(Message::SyncSystemState {
+            sessions: vec![],
+            default_route_interface: None,
         });
         assert!(matches!(app.legacy_state(), ConnectionState::Disconnected));
     }
@@ -338,11 +352,19 @@ mod connection_state_machine {
         set_disconnecting(&mut app, "vpn-a");
         app.runtime.pending_connect = Some(1);
 
-        // Disconnect completes -> complete_disconnect drains pending_connect
+        // Disconnect completes -> the kernel-confirming scan drains
+        // pending_connect via complete_disconnect.
         app.handle_message(Message::DisconnectResult {
             profile: "vpn-a".to_string(),
             success: true,
             error: None,
+        });
+        // Completion is kernel-confirmed: the worker's success keeps the
+        // entry Disconnecting; the next scan reporting the session gone
+        // finishes the disconnect (guards the re-adopt/reconnect loop).
+        app.handle_message(Message::SyncSystemState {
+            sessions: vec![],
+            default_route_interface: None,
         });
 
         // complete_disconnect calls connect_profile(1) for vpn-b.


### PR DESCRIPTION
> **Reframed after further investigation** — originally filed as a hotfix for a field incident where disconnect looped back to connected within ~5s. The incident's dominant cause turned out to be **two vortix TUIs running concurrently**: the second (unpatched) instance saw the first one's teardown as an unexpected drop of *its* tunnel and auto-reconnected it. Single-instance disconnect works most of the time on main. **Not urgent.** This PR still closes a real, timing-dependent hole the incident exposed — details below.

## The window this closes

`OvpnTunnel::down()` sends SIGTERM and returns immediately — it never waits for the process to exit. `openvpn` typically takes another 1–2s to die. In the old code, `DisconnectResult{success}` removed the registry entry right away, opening a window in which a scanner pass sampling the dying process finds a catalog-matching kernel session with **no registry entry** and re-adopts it as an externally-started tunnel. The next pass then reads its exit as an **unexpected drop** — engaging the kill-switch drop policy and scheduling auto-reconnect against a teardown the user asked for. Whether it bites depends on scan timing relative to process exit, so it's intermittent rather than deterministic.

## Fix

On `DisconnectResult` success, keep the entry `Disconnecting`. The scanner's existing `(Disconnecting, no-session)` arm completes the disconnect the moment the kernel confirms the session is gone — and while the entry exists, re-adoption is impossible by construction. The disconnect-timeout arm still force-cleans teardowns that never converge. Completion (pending-connect drain, kill-switch sync, telemetry reset) runs exactly once, kernel-confirmed, at most one scanner tick (~1s) later. This also matches the project's state-authority contract: the kernel, not a worker thread's exit status, is the source of truth.

Verified live on the reporting machine: `Disconnecting → Teardown finished — awaiting kernel confirmation → Disconnected`, no drop counted, no reconnect (the residual reconnect observed during testing was traced to the second running instance, not this code path).

## Tests

- New regression test: a scan captured mid-teardown must neither re-adopt, nor count a drop, nor schedule a reconnect.
- Eight existing tests that asserted worker-word completion now feed the kernel-confirming scan (matching runtime reality).
- Full CI parity locally: fmt, clippy `-D warnings` all targets, all workspace suites, rustdoc, xtask boundary checks.

## Follow-up (separate issue)

The incident's actual trigger — two concurrent vortix instances silently fighting over tunnels — deserves its own guard (warn or refuse on startup when another instance is running). The daemon architecture solves it structurally; a cheap interim check may be worth shipping sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)