### PR TITLE
refactor: consolidate shared runtime plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,15 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,18 +675,6 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "equivalent"
@@ -2899,8 +2878,6 @@ dependencies = [
  "color-eyre",
  "crossterm",
  "directories",
- "dirs",
- "enum_dispatch",
  "figment",
  "libc",
  "open",
@@ -3383,7 +3360,6 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "ignore",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ serde_json = "1.0"
 
 # Configuration
 toml = "1.1"
-dirs = "6"
 directories = "6"
 figment = { version = "0.10", features = ["toml", "env"] }
 
@@ -46,8 +45,6 @@ figment = { version = "0.10", features = ["toml", "env"] }
 tokio = { version = "1", features = ["rt-multi-thread", "process", "time", "macros", "sync", "io-util", "fs", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-enum_dispatch = "0.3"
-
 # Unicode display-width (for footer hint budgeting with multi-byte glyphs)
 unicode-width = "0.2"
 

--- a/crates/vortix/Cargo.toml
+++ b/crates/vortix/Cargo.toml
@@ -62,7 +62,6 @@ serde_json = { workspace = true }
 
 # Configuration
 toml = { workspace = true }
-dirs = { workspace = true }
 
 # Unicode display-width (for footer hint budgeting with multi-byte glyphs)
 unicode-width = { workspace = true }
@@ -77,7 +76,6 @@ tracing-subscriber = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util", "time"] }
 thiserror = { workspace = true }
 directories = { workspace = true }
-enum_dispatch = { workspace = true }
 figment = { workspace = true }
 sha2 = "0.11"
 # Plan 2026-06-02-001 U2 (#191): base64 envelope for OpenVPN SCRV1

--- a/crates/vortix/src/app/connection.rs
+++ b/crates/vortix/src/app/connection.rs
@@ -359,52 +359,6 @@ impl App {
         }
     }
 
-    /// Kill any running VPN process and remove run files for a profile.
-    ///
-    /// routes through the `TunnelKind` dispatch so this no
-    /// longer match-branches on protocol.
-    pub(crate) fn cleanup_vpn_resources(&self, profile_name: &str) {
-        if let Some(profile) = self
-            .runtime
-            .profiles
-            .iter()
-            .find(|p| p.name == profile_name)
-        {
-            use crate::vortix_core::ports::tunnel::{TunnelHandle, TunnelKindTag};
-            use crate::vortix_core::profile::ProfileId;
-
-            let iface = match profile.protocol {
-                Protocol::WireGuard => profile.config_path.to_string_lossy().into_owned(),
-                Protocol::OpenVPN => {
-                    format!("openvpn-{}", utils::sanitize_profile_name(profile_name))
-                }
-            };
-            let pid = match profile.protocol {
-                Protocol::OpenVPN => utils::read_openvpn_pid(profile_name),
-                Protocol::WireGuard => None,
-            };
-            let handle = TunnelHandle {
-                profile_id: ProfileId::new(profile_name),
-                interface_name: iface,
-                pid,
-                started_at: std::time::SystemTime::now(),
-                kind: match profile.protocol {
-                    Protocol::WireGuard => TunnelKindTag::WireGuard,
-                    Protocol::OpenVPN => TunnelKindTag::OpenVpn,
-                },
-            };
-
-            let config_dir =
-                utils::get_app_config_dir().unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
-            let mut tunnel = crate::tunnel::tunnel_for(profile.protocol, &config_dir, "3", 30);
-            let _ = tunnel.down(handle);
-
-            if matches!(profile.protocol, Protocol::OpenVPN) {
-                utils::cleanup_openvpn_run_files(profile_name);
-            }
-        }
-    }
-
     /// Finalize a disconnect: transition to `Disconnected`, sync kill switch,
     /// and drain `pending_connect` (auto-connect to the queued profile, if any).
     pub(crate) fn complete_disconnect(&mut self, profile_name: &str) {

--- a/crates/vortix/src/app/profile.rs
+++ b/crates/vortix/src/app/profile.rs
@@ -168,8 +168,8 @@ impl App {
                 }
             }
 
-            self.save_metadata();
-            self.sort_profiles();
+            self.runtime.save_metadata();
+            self.runtime.sort_profiles();
 
             if let Some(new_idx) = self
                 .runtime
@@ -184,56 +184,6 @@ impl App {
                 format!("Renamed '{old_name}' → '{new_name}'"),
                 ToastType::Success,
             );
-        }
-    }
-
-    pub(crate) fn save_metadata(&self) {
-        use std::collections::HashMap;
-
-        let mut metadata = HashMap::new();
-        for profile in &self.runtime.profiles {
-            let key = profile.config_path.to_string_lossy().to_string();
-            metadata.insert(
-                key,
-                utils::ProfileMetadata {
-                    last_used: profile.last_used,
-                },
-            );
-        }
-
-        let _ = utils::save_profile_metadata(&metadata);
-    }
-
-    /// Sort profiles according to the current `sort_order`.
-    pub(crate) fn sort_profiles(&mut self) {
-        use crate::state::ProfileSortOrder;
-        match self.runtime.sort_order {
-            ProfileSortOrder::NameAsc => {
-                self.runtime.profiles.sort_by(|a, b| a.name.cmp(&b.name));
-            }
-            ProfileSortOrder::NameDesc => {
-                self.runtime.profiles.sort_by(|a, b| b.name.cmp(&a.name));
-            }
-            ProfileSortOrder::LastUsed => {
-                self.runtime.profiles.sort_by(|a, b| {
-                    b.last_used
-                        .unwrap_or(std::time::UNIX_EPOCH)
-                        .cmp(&a.last_used.unwrap_or(std::time::UNIX_EPOCH))
-                });
-            }
-            ProfileSortOrder::Protocol => {
-                fn proto_rank(p: crate::state::Protocol) -> u8 {
-                    match p {
-                        crate::state::Protocol::WireGuard => 0,
-                        crate::state::Protocol::OpenVPN => 1,
-                    }
-                }
-                self.runtime.profiles.sort_by(|a, b| {
-                    proto_rank(a.protocol)
-                        .cmp(&proto_rank(b.protocol))
-                        .then_with(|| a.name.cmp(&b.name))
-                });
-            }
         }
     }
 
@@ -280,7 +230,7 @@ impl App {
             }
         }
 
-        self.sort_profiles();
+        self.runtime.sort_profiles();
 
         if let Some(name) = last_imported_name {
             if let Some(idx) = self.runtime.profiles.iter().position(|p| p.name == name) {

--- a/crates/vortix/src/app/update.rs
+++ b/crates/vortix/src/app/update.rs
@@ -292,7 +292,7 @@ impl App {
                     .and_then(|i| self.runtime.profiles.get(i))
                     .map(|p| p.name.clone());
                 self.runtime.sort_order = self.runtime.sort_order.next();
-                self.sort_profiles();
+                self.runtime.sort_profiles();
                 if let Some(name) = selected_name {
                     if let Some(new_idx) = self.runtime.profiles.iter().position(|p| p.name == name)
                     {
@@ -578,7 +578,7 @@ impl App {
             if let Some(p) = self.runtime.profiles.iter_mut().find(|p| p.name == profile) {
                 p.last_used = Some(std::time::SystemTime::now());
             }
-            self.save_metadata();
+            self.runtime.save_metadata();
 
             self.runtime.last_connected_profile = Some(profile.clone());
             self.log(&format!("STATUS: Connected to '{profile}'"));
@@ -598,7 +598,7 @@ impl App {
             // dismisses. Before this, failed connects left no trace
             // in the registry and the sidebar reverted to blank.
             self.mirror_failed_into_registry(&profile, &err_msg);
-            self.cleanup_vpn_resources(&profile);
+            self.runtime.cleanup_vpn_resources(&profile);
 
             // Attempt retry with exponential backoff if configured.
             // Per-profile retry (): each profile's attempt
@@ -1150,7 +1150,7 @@ impl App {
             "WARN: Disconnect timed out for '{profile_name}' after {}s, forcing cleanup",
             self.runtime.config.disconnect_timeout
         ));
-        self.cleanup_vpn_resources(profile_name);
+        self.runtime.cleanup_vpn_resources(profile_name);
         self.runtime.pending_connect = None;
         if self.legacy_matches(profile_name) {
             self.runtime.session_start = None;
@@ -1475,7 +1475,7 @@ impl App {
     }
 
     fn handle_connection_timeout(&mut self, profile_name: String) {
-        self.cleanup_vpn_resources(&profile_name);
+        self.runtime.cleanup_vpn_resources(&profile_name);
         let profile_id = crate::vortix_core::profile::ProfileId::new(&profile_name);
         self.runtime.session_start = None;
         self.runtime.pending_connect = None;

--- a/crates/vortix/src/config.rs
+++ b/crates/vortix/src/config.rs
@@ -211,7 +211,7 @@ fn real_user_home() -> Option<PathBuf> {
             return home_dir_for_user(&sudo_user);
         }
     }
-    dirs::home_dir()
+    crate::utils::home_dir()
 }
 
 /// Looks up a user's home directory from `/etc/passwd` via `getpwnam`.

--- a/crates/vortix/src/core/scanner.rs
+++ b/crates/vortix/src/core/scanner.rs
@@ -4,19 +4,9 @@
 //! by scanning system interfaces and processes for `WireGuard` and `OpenVPN` sessions.
 
 use crate::app::{Protocol, VpnProfile};
-use crate::vortix_process::CommandSpec;
+use crate::vortix_process::simple_output as cmd_output;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
-
-/// Run a command and return its output.
-///
-/// No timeout — the scanner runs in a background thread so it cannot block the UI.
-/// All commands here are read-only inspection (`ps`, `wg show`, `ip addr`, `lsof`)
-/// and run with no privilege requirement.
-fn cmd_output(program: &str, args: &[&str]) -> Option<std::process::Output> {
-    let owned_args = args.iter().map(|s| (*s).to_string()).collect();
-    crate::vortix_process::run_to_output(CommandSpec::oneshot(program, owned_args)).ok()
-}
 
 /// Information about an active VPN session detected on the system.
 #[derive(Clone, Debug)]
@@ -124,7 +114,14 @@ pub fn get_active_profiles(profiles: &[VpnProfile]) -> Vec<ActiveSession> {
     let mut active = Vec::new();
 
     // 1. Batch lookup for OpenVPN
-    let openvpn_pids = get_all_openvpn_pids();
+    let openvpn_pids = if profiles
+        .iter()
+        .any(|profile| matches!(profile.protocol, Protocol::OpenVPN))
+    {
+        get_all_openvpn_pids()
+    } else {
+        std::collections::HashMap::new()
+    };
     for profile in profiles {
         let session_info = match profile.protocol {
             Protocol::WireGuard => check_wireguard_by_name(&profile.name),
@@ -180,28 +177,15 @@ fn check_wireguard_by_name(name: &str) -> Option<ActiveSession> {
     // Platform-dispatched interface check via the platform aggregate.
     let platform = crate::platform::current_platform();
 
-    if !platform.interface.check_wireguard_interface(name) {
-        return None;
-    }
-
     // On macOS, `resolve_wireguard_interface` reads /var/run/wireguard/
-    // <name>.name and returns Some(utunN). On Linux, it returns None
-    // because the kernel device IS the config name — the fallback to
-    // `name.to_string()` is correct. The Some-branch (macOS happy
-    // path) is authoritative; the None fallback is authoritative on
-    // Linux but unauthoritative on macOS (where it indicates an
-    // anomalous wg-quick install / permission state).
-    let resolved = platform.interface.resolve_wireguard_interface(name);
-    let interface_name = resolved.clone().unwrap_or_else(|| name.to_string());
-    // `iface_authoritative` is true when the port returned Some, OR
-    // when we're on Linux (where the port always returns None and the
-    // basename IS the kernel name). The narrow unauthoritative case is
-    // macOS + None — the .name file was missing.
-    let iface_authoritative = resolved.is_some() || cfg!(target_os = "linux");
+    // <name>.name and returns Some(utunN). On Linux, the kernel device
+    // is the config name. Resolution also establishes existence, so a
+    // separate check would repeat the same `wg show` subprocess.
+    let interface_name = platform.interface.resolve_wireguard_interface(name)?;
 
     let mut session = ActiveSession {
         interface: interface_name.clone(),
-        interface_authoritative: iface_authoritative,
+        interface_authoritative: true,
         ..Default::default()
     };
 

--- a/crates/vortix/src/platform/aggregate.rs
+++ b/crates/vortix/src/platform/aggregate.rs
@@ -128,7 +128,7 @@ pub struct MockDns {
 /// Scriptable mock for the `Interface` port.
 #[derive(Debug, Default, Clone)]
 pub struct MockInterface {
-    /// If true, `check_wireguard_interface` always returns true.
+    /// If true, resolution falls back to the requested profile name.
     pub wg_present: bool,
     /// Override the value returned by `resolve_wireguard_interface`.
     /// `Some("utun7")` simulates the macOS case where wg-quick maps
@@ -261,21 +261,6 @@ pub enum InterfaceKind {
 }
 
 impl InterfaceKind {
-    /// Whether a `WireGuard` interface exists for this profile name.
-    #[must_use]
-    pub fn check_wireguard_interface(&self, name: &str) -> bool {
-        use crate::vortix_core::ports::interface::Interface;
-        match self {
-            #[cfg(target_os = "macos")]
-            Self::Macos => platform_impl::MacInterface::check_wireguard_interface(name),
-            #[cfg(target_os = "linux")]
-            Self::Linux => platform_impl::LinuxInterface::check_wireguard_interface(name),
-            #[cfg(target_os = "windows")]
-            Self::Windows => platform_impl::WindowsInterface::check_wireguard_interface(name),
-            Self::Mock(m) => m.wg_present,
-        }
-    }
-
     /// Resolve the real interface name for a `WireGuard` profile.
     #[must_use]
     pub fn resolve_wireguard_interface(&self, name: &str) -> Option<String> {

--- a/crates/vortix/src/platform/mod.rs
+++ b/crates/vortix/src/platform/mod.rs
@@ -6,6 +6,7 @@
 //! over to the `Platform` aggregate.
 
 pub mod aggregate;
+pub(crate) mod route_probe;
 
 #[cfg(target_os = "linux")]
 pub mod linux;

--- a/crates/vortix/src/platform/route_probe.rs
+++ b/crates/vortix/src/platform/route_probe.rs
@@ -1,0 +1,91 @@
+//! Shared failure backoff for platform route-table probes.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use crate::vortix_process::CommandSpec;
+
+pub(crate) enum ProbeOutcome {
+    BackedOff,
+    Success(String),
+    Failed {
+        consecutive_failures: u32,
+        cooldown: Duration,
+    },
+}
+
+struct ProbeBackoff {
+    consecutive_failures: u32,
+    next_allowed: Instant,
+}
+
+/// Process-wide state for one platform route probe.
+pub(crate) struct RouteProbe {
+    state: OnceLock<Mutex<ProbeBackoff>>,
+}
+
+impl RouteProbe {
+    pub(crate) const fn new() -> Self {
+        Self {
+            state: OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn run(&self, spec: CommandSpec) -> ProbeOutcome {
+        let state = self.state.get_or_init(|| {
+            Mutex::new(ProbeBackoff {
+                consecutive_failures: 0,
+                next_allowed: Instant::now(),
+            })
+        });
+
+        {
+            let state = state.lock().expect("backoff state mutex poisoned");
+            if Instant::now() < state.next_allowed {
+                return ProbeOutcome::BackedOff;
+            }
+        }
+
+        let result = crate::vortix_process::run_to_output(spec);
+        let mut state = state.lock().expect("backoff state mutex poisoned");
+        if let Ok(output) = result {
+            state.consecutive_failures = 0;
+            state.next_allowed = Instant::now();
+            return ProbeOutcome::Success(String::from_utf8_lossy(&output.stdout).into_owned());
+        }
+
+        state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+        let cooldown = cooldown_for_failures(state.consecutive_failures);
+        state.next_allowed = Instant::now() + cooldown;
+        ProbeOutcome::Failed {
+            consecutive_failures: state.consecutive_failures,
+            cooldown,
+        }
+    }
+}
+
+fn cooldown_for_failures(failures: u32) -> Duration {
+    Duration::from_secs(match failures {
+        0..=2 => 0,
+        3..=5 => 5,
+        6..=10 => 15,
+        _ => 60,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cooldown_ladder_escalates_then_caps() {
+        assert_eq!(cooldown_for_failures(0), Duration::ZERO);
+        assert_eq!(cooldown_for_failures(2), Duration::ZERO);
+        assert_eq!(cooldown_for_failures(3), Duration::from_secs(5));
+        assert_eq!(cooldown_for_failures(5), Duration::from_secs(5));
+        assert_eq!(cooldown_for_failures(6), Duration::from_secs(15));
+        assert_eq!(cooldown_for_failures(10), Duration::from_secs(15));
+        assert_eq!(cooldown_for_failures(11), Duration::from_secs(60));
+        assert_eq!(cooldown_for_failures(1_000_000), Duration::from_secs(60));
+    }
+}

--- a/crates/vortix/src/utils.rs
+++ b/crates/vortix/src/utils.rs
@@ -212,23 +212,9 @@ pub fn get_tmp_config_dir(session_id: &str) -> std::io::Result<std::path::PathBu
     Ok(session_dir)
 }
 
-/// Returns the `OpenVPN` runtime directory path for a given profile.
-///
-/// Creates `~/.config/vortix/run/` if it doesn't exist.
-/// Strip a profile name down to ASCII `[A-Za-z0-9_-]` so it is safe for use
-/// in daemon names, filenames, and pkill regex patterns.
-#[must_use]
-pub fn sanitize_profile_name(name: &str) -> String {
-    name.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
+/// Strip a profile name down to ASCII `[A-Za-z0-9_-]` for safe use in
+/// daemon names, filenames, and process-match patterns.
+pub use crate::vortix_core::profile::sanitize_profile_name;
 
 /// Returns `(pid_path, log_path)` for the given profile name.
 ///
@@ -687,37 +673,11 @@ pub fn format_relative_time(time: std::time::SystemTime) -> String {
 
 /// Returns the user's home directory.
 ///
-/// Checks `$HOME` first, then falls back to the system password database
-/// via `getpwuid` for containers, cron jobs, and systemd services where
-/// `$HOME` may be unset.
+/// Uses the same platform-aware base-directory resolver as settings and
+/// journal persistence.
+#[must_use]
 pub fn home_dir() -> Option<std::path::PathBuf> {
-    std::env::var("HOME")
-        .ok()
-        .map(std::path::PathBuf::from)
-        .or_else(home_dir_from_passwd)
-}
-
-/// Fallback: resolve home directory from /etc/passwd via libc.
-#[cfg(unix)]
-#[allow(unsafe_code)]
-fn home_dir_from_passwd() -> Option<std::path::PathBuf> {
-    // SAFETY: getuid() is always safe; getpwuid() returns a static pointer
-    // that is valid until the next call to any getpw* function. We copy the
-    // data immediately so the pointer is not held across calls.
-    unsafe {
-        let uid = libc::getuid();
-        let pw = libc::getpwuid(uid);
-        if pw.is_null() {
-            return None;
-        }
-        let home = std::ffi::CStr::from_ptr((*pw).pw_dir);
-        home.to_str().ok().map(std::path::PathBuf::from)
-    }
-}
-
-#[cfg(not(unix))]
-fn home_dir_from_passwd() -> Option<std::path::PathBuf> {
-    None
+    directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf())
 }
 
 /// Profile metadata for persistence

--- a/crates/vortix/src/vortix_core/cidr.rs
+++ b/crates/vortix/src/vortix_core/cidr.rs
@@ -10,7 +10,7 @@
 //! Implemented directly — no external CIDR crate — so the dependency
 //! surface stays small.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -90,6 +90,31 @@ impl Cidr {
             _ => false,
         }
     }
+}
+
+impl std::fmt::Display for Cidr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.addr, self.prefix_len)
+    }
+}
+
+/// The ordered RFC 1918 private IPv4 ranges used by platform firewalls.
+#[must_use]
+pub const fn rfc1918_ranges() -> [Cidr; 3] {
+    [
+        Cidr {
+            addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)),
+            prefix_len: 8,
+        },
+        Cidr {
+            addr: IpAddr::V4(Ipv4Addr::new(172, 16, 0, 0)),
+            prefix_len: 12,
+        },
+        Cidr {
+            addr: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 0)),
+            prefix_len: 16,
+        },
+    ]
 }
 
 /// Return the CIDRs from `a` that intersect any CIDR in `b`. O(|a|·|b|);

--- a/crates/vortix/src/vortix_core/engine/handle.rs
+++ b/crates/vortix/src/vortix_core/engine/handle.rs
@@ -8,8 +8,6 @@
 //! Phase B daemon work (idea 4) adds a `Remote(RemoteHandle)` variant
 //! additively (the enum is `#[non_exhaustive]`).
 
-use std::sync::Arc;
-
 use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::vortix_core::engine::error::EngineError;
@@ -240,7 +238,6 @@ fn actor_loop<T: Tunnel>(
                 let events = engine.handle(input);
                 let count = events.len();
                 // Best-effort journal append — failures are non-fatal.
-                let journal = Arc::new(journal.clone());
                 for ev in events {
                     let _ = journal.append(ev);
                 }

--- a/crates/vortix/src/vortix_core/ports/interface.rs
+++ b/crates/vortix/src/vortix_core/ports/interface.rs
@@ -6,9 +6,6 @@
 /// name and the actual kernel/userspace interface, query process state, and
 /// extract IP/MTU information.
 pub trait Interface {
-    /// Check whether a `WireGuard` interface exists for the given profile name.
-    fn check_wireguard_interface(name: &str) -> bool;
-
     /// Resolve the real interface name for a `WireGuard` profile.
     fn resolve_wireguard_interface(name: &str) -> Option<String>;
 

--- a/crates/vortix/src/vortix_core/ports/process.rs
+++ b/crates/vortix/src/vortix_core/ports/process.rs
@@ -222,7 +222,7 @@ pub enum ProcessError {
 ///
 /// Implementations live in `vortix-process` (`RealRunner` for production, `MockRunner`
 /// for tests). The trait uses native AFIT (Rust 1.75+); the `vortix-process` crate
-/// provides an `enum_dispatch`-driven enum wrapper that callers hold by value.
+/// provides a hand-dispatched enum wrapper that callers hold by value.
 pub trait CommandRunner: Send + Sync {
     /// Run a one-shot subprocess to completion.
     fn run(

--- a/crates/vortix/src/vortix_core/profile.rs
+++ b/crates/vortix/src/vortix_core/profile.rs
@@ -8,6 +8,21 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+/// Strip a profile name down to ASCII `[A-Za-z0-9_-]` for safe use in
+/// daemon names, filenames, and process-match patterns.
+#[must_use]
+pub fn sanitize_profile_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 /// Stable identifier for a profile, derived from disk path + name.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ProfileId(String);

--- a/crates/vortix/src/vortix_platform_linux/firewall.rs
+++ b/crates/vortix/src/vortix_platform_linux/firewall.rs
@@ -29,7 +29,7 @@
 use std::fmt::Write;
 use std::net::IpAddr;
 
-use crate::vortix_core::cidr::Cidr;
+use crate::vortix_core::cidr::{rfc1918_ranges, Cidr};
 use crate::vortix_core::cidr_subtract::cidr_subtract;
 use crate::vortix_core::ports::killswitch::{
     ActiveTunnelInfo, Killswitch, KillswitchError, Result,
@@ -48,23 +48,6 @@ enum FirewallBackend {
 
 /// Linux firewall implementation supporting iptables and nftables.
 pub struct IptablesFirewall;
-
-/// Format a `Cidr` as `addr/prefix` (e.g. `10.0.0.0/8`). Used for the v4
-/// RFC1918 lines emitted into the iptables ruleset.
-fn fmt_cidr(c: &Cidr) -> String {
-    format!("{}/{}", c.addr, c.prefix_len)
-}
-
-/// RFC1918 base list — the v4 private-network space allowed to bypass the
-/// killswitch onto the underlay. Secondaries' `declared_cidrs` are
-/// subtracted from this; primaries are excluded from the remove list per
-/// Q-DEF-9 D-6.
-fn rfc1918_base() -> Vec<Cidr> {
-    ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
-        .iter()
-        .map(|s| s.parse().expect("static RFC1918 CIDRs parse"))
-        .collect()
-}
 
 impl IptablesFirewall {
     /// Detect which firewall backend is available, preferring iptables.
@@ -123,9 +106,9 @@ impl IptablesFirewall {
             .filter(|t| !t.is_primary)
             .flat_map(|t| t.declared_cidrs.iter().copied())
             .collect();
-        let rfc1918 = cidr_subtract(&rfc1918_base(), &secondary_cidrs);
+        let rfc1918 = cidr_subtract(&rfc1918_ranges(), &secondary_cidrs);
         for c in &rfc1918 {
-            writeln!(rules, "-A OUTPUT -d {} -j ACCEPT", fmt_cidr(c)).unwrap();
+            writeln!(rules, "-A OUTPUT -d {c} -j ACCEPT").unwrap();
         }
 
         // DHCP — must precede the per-tunnel rules so a DHCP renew on the
@@ -389,14 +372,6 @@ impl IptablesFirewall {
     }
 }
 
-fn is_root() -> bool {
-    // SAFETY: `geteuid` is a thread-safe getter with no side effects.
-    #[allow(unsafe_code)]
-    unsafe {
-        libc::geteuid() == 0
-    }
-}
-
 impl Killswitch for IptablesFirewall {
     /// Engage the killswitch with a ruleset covering every tunnel in
     /// `active`. The iptables backend pipes a full ruleset through
@@ -409,7 +384,7 @@ impl Killswitch for IptablesFirewall {
     /// 1-4 only) — used during early bring-up and on hard-fail Armed
     /// states.
     fn enable_blocking_multi(active: &[ActiveTunnelInfo]) -> Result<()> {
-        if !is_root() {
+        if !crate::utils::is_root() {
             error!(target: "vortix::killswitch", "kill switch requires root privileges");
             return Err(KillswitchError::NotRoot);
         }
@@ -455,7 +430,7 @@ impl Killswitch for IptablesFirewall {
     fn disable_blocking() -> Result<()> {
         info!(target: "vortix::killswitch", "disabling kill switch");
 
-        if !is_root() {
+        if !crate::utils::is_root() {
             error!(target: "vortix::killswitch", "disabling kill switch requires root");
             return Err(KillswitchError::NotRoot);
         }

--- a/crates/vortix/src/vortix_platform_linux/interface.rs
+++ b/crates/vortix/src/vortix_platform_linux/interface.rs
@@ -6,28 +6,12 @@
 //! on iproute2 for read-only interface inspection.
 
 use crate::vortix_core::ports::interface::Interface;
-use crate::vortix_process::CommandSpec;
-
-/// Run a command and return its output.
-///
-/// No timeout — called from the scanner's background thread, cannot block the UI.
-/// All commands are read-only inspections that run unprivileged.
-fn cmd_output(program: &str, args: &[&str]) -> Option<std::process::Output> {
-    let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
-    crate::vortix_process::run_to_output(CommandSpec::oneshot(program, owned)).ok()
-}
+use crate::vortix_process::simple_output as cmd_output;
 
 /// Linux interface detection using `libc::getifaddrs`, `/sys/class/net`, and `wg show`.
 pub struct LinuxInterface;
 
 impl Interface for LinuxInterface {
-    fn check_wireguard_interface(name: &str) -> bool {
-        // On Linux, WireGuard creates interfaces directly (wg0, wg1, etc.)
-        // Also check using `wg show` which works for kernel and userspace WireGuard.
-        // `wg` stays a shell-out (it's the irreducible WireGuard tool).
-        check_wg_interface_exists(name)
-    }
-
     fn resolve_wireguard_interface(name: &str) -> Option<String> {
         // Linux doesn't use /var/run/wireguard/*.name mapping files
         // The interface name IS the WireGuard interface
@@ -82,32 +66,7 @@ fn check_wg_interface_exists(name: &str) -> bool {
 /// on procps.
 ///
 pub(crate) fn find_pid_with_cmdline_substrings(needles: &[&str]) -> Option<u32> {
-    let needles_lower: Vec<String> = needles.iter().map(|n| n.to_lowercase()).collect();
-
-    let entries = std::fs::read_dir("/proc").ok()?;
-    for entry in entries.flatten() {
-        let file_name = entry.file_name();
-        let Some(name) = file_name.to_str() else {
-            continue;
-        };
-        // Skip non-PID entries (those are numeric).
-        let Ok(pid) = name.parse::<u32>() else {
-            continue;
-        };
-        // cmdline is null-separated; replace with spaces for substring
-        // matching against the legacy `ps args` format.
-        let cmdline_path = format!("/proc/{pid}/cmdline");
-        let Ok(raw) = std::fs::read(&cmdline_path) else {
-            continue; // PID disappeared between readdir and read — fine
-        };
-        let cmdline = String::from_utf8_lossy(&raw)
-            .replace('\0', " ")
-            .to_lowercase();
-        if needles_lower.iter().all(|n| cmdline.contains(n)) {
-            return Some(pid);
-        }
-    }
-    None
+    matching_pids(needles, Some(1)).into_iter().next()
 }
 
 /// Walk `/proc/[pid]/cmdline` and return EVERY PID whose cmdline contains
@@ -117,7 +76,11 @@ pub(crate) fn find_pid_with_cmdline_substrings(needles: &[&str]) -> Option<u32> 
 /// walk as the single-PID variant but collects all matches.
 ///
 pub(crate) fn find_all_pids_with_cmdline_substring(needle: &str) -> Vec<u32> {
-    let needle_lower = needle.to_lowercase();
+    matching_pids(&[needle], None)
+}
+
+fn matching_pids(needles: &[&str], limit: Option<usize>) -> Vec<u32> {
+    let needles: Vec<String> = needles.iter().map(|needle| needle.to_lowercase()).collect();
     let mut matches = Vec::new();
     let Ok(entries) = std::fs::read_dir("/proc") else {
         return matches;
@@ -137,8 +100,11 @@ pub(crate) fn find_all_pids_with_cmdline_substring(needle: &str) -> Vec<u32> {
         let cmdline = String::from_utf8_lossy(&raw)
             .replace('\0', " ")
             .to_lowercase();
-        if cmdline.contains(&needle_lower) {
+        if needles.iter().all(|needle| cmdline.contains(needle)) {
             matches.push(pid);
+            if limit.is_some_and(|limit| matches.len() == limit) {
+                break;
+            }
         }
     }
     matches

--- a/crates/vortix/src/vortix_platform_linux/route_table.rs
+++ b/crates/vortix/src/vortix_platform_linux/route_table.rs
@@ -14,9 +14,9 @@
 //! See `vortix_platform_macos/route_table.rs` for the cross-platform
 //! rationale and the choice of 8.8.8.8 as the probe target.
 
-use std::sync::{Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use crate::platform::route_probe::{ProbeOutcome, RouteProbe};
 use crate::vortix_core::ports::route_table::RouteTable;
 use crate::vortix_process::CommandSpec;
 
@@ -31,30 +31,7 @@ const ROUTE_QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 /// a broken Linux network state doesn't keep the scanner thread + the
 /// network-monitor thread both spinning on a doomed `ip route` call
 /// every couple of seconds.
-struct ProbeBackoff {
-    consecutive_fails: u32,
-    next_allowed: Instant,
-}
-
-fn backoff_state() -> &'static Mutex<ProbeBackoff> {
-    static STATE: OnceLock<Mutex<ProbeBackoff>> = OnceLock::new();
-    STATE.get_or_init(|| {
-        Mutex::new(ProbeBackoff {
-            consecutive_fails: 0,
-            next_allowed: Instant::now(),
-        })
-    })
-}
-
-fn cooldown_for_fails(fails: u32) -> Duration {
-    let secs = match fails {
-        0..=2 => 0,
-        3..=5 => 5,
-        6..=10 => 15,
-        _ => 60,
-    };
-    Duration::from_secs(secs)
-}
+static ROUTE_PROBE: RouteProbe = RouteProbe::new();
 
 /// Public-internet probe target. See module-level docs for why this is
 /// preferred over `ip route show default`.
@@ -80,44 +57,31 @@ impl RouteTable for LinuxRouteTable {
 ///
 /// Returns `None` if the subprocess fails so callers can degrade gracefully.
 fn run_ip_route_show_default() -> Option<String> {
-    {
-        let state = backoff_state()
-            .lock()
-            .expect("backoff state mutex poisoned");
-        if Instant::now() < state.next_allowed {
-            return None;
-        }
-    }
-
-    let result = crate::vortix_process::run_to_output(
+    match ROUTE_PROBE.run(
         // xtask:allow-shell-regression: `ip route get <ip>` is the canonical Linux routing-table inspection — no libc equivalent that returns the chosen egress dev without rolling our own netlink RTNETLINK parser.
         CommandSpec::oneshot(
             "ip",
             vec!["route".into(), "get".into(), ROUTE_PROBE_TARGET.into()],
         )
         .timeout(ROUTE_QUERY_TIMEOUT),
-    );
-
-    let mut state = backoff_state()
-        .lock()
-        .expect("backoff state mutex poisoned");
-    if let Ok(output) = result {
-        state.consecutive_fails = 0;
-        state.next_allowed = Instant::now();
-        return Some(String::from_utf8_lossy(&output.stdout).into_owned());
+    ) {
+        ProbeOutcome::Success(stdout) => Some(stdout),
+        ProbeOutcome::BackedOff => None,
+        ProbeOutcome::Failed {
+            consecutive_failures,
+            cooldown,
+        } => {
+            if consecutive_failures == 1 || cooldown >= Duration::from_secs(5) {
+                tracing::warn!(
+                    target: "vortix::vortix_platform_linux::route_table",
+                    consecutive_fails = consecutive_failures,
+                    cooldown_secs = cooldown.as_secs(),
+                    "`ip route get` probe failed; backing off to spare the tokio runtime"
+                );
+            }
+            None
+        }
     }
-    state.consecutive_fails = state.consecutive_fails.saturating_add(1);
-    let cooldown = cooldown_for_fails(state.consecutive_fails);
-    state.next_allowed = Instant::now() + cooldown;
-    if state.consecutive_fails == 1 || cooldown >= Duration::from_secs(5) {
-        tracing::warn!(
-            target: "vortix::vortix_platform_linux::route_table",
-            consecutive_fails = state.consecutive_fails,
-            cooldown_secs = cooldown.as_secs(),
-            "`ip route get` probe failed; backing off to spare the tokio runtime"
-        );
-    }
-    None
 }
 
 /// Extract the gateway IP from any line containing `via <ip>`.

--- a/crates/vortix/src/vortix_platform_macos/firewall.rs
+++ b/crates/vortix/src/vortix_platform_macos/firewall.rs
@@ -15,7 +15,7 @@ use std::io::Write as IoWrite;
 use std::net::IpAddr;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-use crate::vortix_core::cidr::Cidr;
+use crate::vortix_core::cidr::{rfc1918_ranges, Cidr};
 use crate::vortix_core::cidr_subtract::cidr_subtract;
 use crate::vortix_core::ports::killswitch::{
     ActiveTunnelInfo, Killswitch, KillswitchError, Result,
@@ -48,30 +48,6 @@ fn pfctl_load_stdin(ruleset: &[u8]) -> std::io::Result<std::process::Output> {
             .privilege(PrivilegeReq::Root)
             .stdin(ruleset.to_vec()),
     )
-}
-
-fn is_root() -> bool {
-    // SAFETY: `geteuid` is a thread-safe getter with no side effects.
-    #[allow(unsafe_code)]
-    unsafe {
-        libc::geteuid() == 0
-    }
-}
-
-/// Format a `Cidr` as pf-syntax `addr/prefix` (e.g. `10.0.0.0/8`). pf
-/// accepts this for both v4 and v6; we only emit v4 today.
-fn fmt_cidr(c: &Cidr) -> String {
-    format!("{}/{}", c.addr, c.prefix_len)
-}
-
-/// The RFC1918 base list. `enable_blocking_multi` subtracts the union of
-/// secondaries' `declared_cidrs` from this; primaries don't contribute
-/// (see `cidr_subtract` docs / Q-DEF-9 D-6).
-fn rfc1918_base() -> Vec<Cidr> {
-    ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
-        .iter()
-        .map(|s| s.parse().expect("static RFC1918 CIDRs parse"))
-        .collect()
 }
 
 /// macOS pf-based firewall implementation.
@@ -115,7 +91,7 @@ impl PfFirewall {
             .filter(|t| !t.is_primary)
             .flat_map(|t| t.declared_cidrs.iter().copied())
             .collect();
-        let rfc1918 = cidr_subtract(&rfc1918_base(), &secondary_cidrs);
+        let rfc1918 = cidr_subtract(&rfc1918_ranges(), &secondary_cidrs);
 
         writeln!(
             rules,
@@ -123,7 +99,7 @@ impl PfFirewall {
         )
         .unwrap();
         for c in &rfc1918 {
-            writeln!(rules, "pass out quick to {}", fmt_cidr(c)).unwrap();
+            writeln!(rules, "pass out quick to {c}").unwrap();
         }
         writeln!(rules).unwrap();
 
@@ -215,7 +191,7 @@ impl Killswitch for PfFirewall {
             "killswitch.engage"
         );
 
-        if !is_root() {
+        if !crate::utils::is_root() {
             error!(target: "vortix::killswitch", "kill switch requires root privileges");
             return Err(KillswitchError::NotRoot);
         }
@@ -267,7 +243,7 @@ impl Killswitch for PfFirewall {
     fn disable_blocking() -> Result<()> {
         info!(target: "vortix::killswitch", "disabling kill switch");
 
-        if !is_root() {
+        if !crate::utils::is_root() {
             error!(target: "vortix::killswitch", "disabling kill switch requires root");
             return Err(KillswitchError::NotRoot);
         }

--- a/crates/vortix/src/vortix_platform_macos/interface.rs
+++ b/crates/vortix/src/vortix_platform_macos/interface.rs
@@ -5,31 +5,17 @@
 //! and `lsof -t <socket>` shell-outs with direct libc / libproc calls.
 
 use crate::vortix_core::ports::interface::Interface;
-use crate::vortix_process::CommandSpec;
+use crate::vortix_process::simple_output as cmd_output;
 use std::path::{Path, PathBuf};
 
 use super::libproc_ffi::{self, SocketView};
 
 const WIREGUARD_RUN_DIR: &str = "/var/run/wireguard";
 
-/// Run a command and return its output.
-///
-/// No timeout — called from the scanner's background thread, cannot block the UI.
-/// All commands here are read-only inspections that run unprivileged.
-fn cmd_output(program: &str, args: &[&str]) -> Option<std::process::Output> {
-    let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
-    crate::vortix_process::run_to_output(CommandSpec::oneshot(program, owned)).ok()
-}
-
 /// macOS interface detection using libc + /var/run/wireguard/*.name files.
 pub struct MacInterface;
 
 impl Interface for MacInterface {
-    fn check_wireguard_interface(name: &str) -> bool {
-        let pid_file = PathBuf::from(WIREGUARD_RUN_DIR).join(format!("{name}.name"));
-        pid_file.exists() || check_wg_interface_exists(name)
-    }
-
     fn resolve_wireguard_interface(name: &str) -> Option<String> {
         let pid_file = PathBuf::from(WIREGUARD_RUN_DIR).join(format!("{name}.name"));
         if pid_file.exists() {
@@ -64,9 +50,8 @@ impl Interface for MacInterface {
         // Per-interface (vs the interface listing):
         // ifconfig <iface> replaced with libc::getifaddrs walk for the
         // named interface. Same data, no PATH dependency.
-        let ip = get_interface_ipv4(interface).unwrap_or_default();
-        let mtu = get_interface_mtu(interface).unwrap_or_default();
-        (ip, mtu)
+        let (ip, mtu) = get_interface_addr_and_mtu(interface);
+        (ip.unwrap_or_default(), mtu.unwrap_or_default())
     }
 }
 
@@ -138,18 +123,6 @@ fn get_interface_addr_and_mtu(interface: &str) -> (Option<String>, Option<String
     }
 }
 
-fn get_interface_ipv4(interface: &str) -> Option<String> {
-    get_interface_addr_and_mtu(interface).0
-}
-
-fn get_interface_mtu(interface: &str) -> Option<String> {
-    get_interface_addr_and_mtu(interface).1
-}
-
-// `PROC_ALL_PIDS` is not re-exported by the libc crate as of 0.2.x —
-// define it locally from Apple's <sys/proc_info.h>. Value is `1`.
-const PROC_ALL_PIDS: u32 = 1;
-
 /// find a process whose binary path contains the given
 /// substring (and optionally a second substring). Walks the live process
 /// list via `libc::proc_listpids` and inspects each PID's path via
@@ -158,101 +131,34 @@ const PROC_ALL_PIDS: u32 = 1;
 /// Returns the first matching PID, or None. Substring match is
 /// case-insensitive — matches the prior `ps` parser's behavior.
 pub(crate) fn find_pid_with_cmdline_substring(needle: &str, also: Option<&str>) -> Option<u32> {
-    let pids = list_all_pids()?;
-    let needle_lower = needle.to_lowercase();
-    let also_lower = also.map(str::to_lowercase);
-    for pid in pids {
-        let Some(path_lower) = pid_path_lower(pid) else {
-            continue;
-        };
-        if !path_lower.contains(&needle_lower) {
-            continue;
-        }
-        if let Some(ref a) = also_lower {
-            if !path_lower.contains(a) {
-                continue;
-            }
-        }
-        if let Ok(pid_u32) = u32::try_from(pid) {
-            return Some(pid_u32);
-        }
-    }
-    None
+    let needles: Vec<&str> = std::iter::once(needle).chain(also).collect();
+    matching_pids(&needles, Some(1)).into_iter().next()
 }
 
 /// find ALL processes whose binary path contains the given
 /// substring. Used by the OVPN tunnel teardown to replace `pkill -f`.
 pub(crate) fn find_all_pids_with_cmdline_substring(needle: &str) -> Vec<u32> {
-    let Some(pids) = list_all_pids() else {
-        return Vec::new();
-    };
-    let needle_lower = needle.to_lowercase();
+    matching_pids(&[needle], None)
+}
+
+fn matching_pids(needles: &[&str], limit: Option<usize>) -> Vec<u32> {
+    let needles: Vec<String> = needles.iter().map(|needle| needle.to_lowercase()).collect();
     let mut matches = Vec::new();
-    for pid in pids {
-        let Some(path_lower) = pid_path_lower(pid) else {
+    for pid in libproc_ffi::list_all_pids() {
+        let Some(path_lower) = libproc_ffi::pid_path(pid).map(|path| path.to_lowercase()) else {
             continue;
         };
-        if path_lower.contains(&needle_lower) {
-            if let Ok(pid_u32) = u32::try_from(pid) {
-                matches.push(pid_u32);
+        if needles.iter().all(|needle| path_lower.contains(needle)) {
+            let Ok(pid) = u32::try_from(pid) else {
+                continue;
+            };
+            matches.push(pid);
+            if limit.is_some_and(|limit| matches.len() == limit) {
+                break;
             }
         }
     }
     matches
-}
-
-/// Enumerate every live PID via `libc::proc_listpids(PROC_ALL_PIDS)`.
-/// Returns `None` if the syscall fails.
-fn list_all_pids() -> Option<Vec<libc::pid_t>> {
-    // SAFETY: sizing call (NULL buf) returns required bytes. Then
-    // allocate and call again. Returns -1 on error.
-    #[allow(unsafe_code)]
-    unsafe {
-        let needed = libc::proc_listpids(PROC_ALL_PIDS, 0, std::ptr::null_mut(), 0);
-        // `needed > 0` is the only case yielding usable buffer size info.
-        let needed_usize = usize::try_from(needed).ok().filter(|&n| n > 0)?;
-        let count_hint = needed_usize / std::mem::size_of::<libc::pid_t>();
-        let mut pids: Vec<libc::pid_t> = vec![0; count_hint + 16]; // headroom
-        let buf_bytes = pids.len() * std::mem::size_of::<libc::pid_t>();
-        let Ok(buf_bytes_i32) = libc::c_int::try_from(buf_bytes) else {
-            return None;
-        };
-        let written = libc::proc_listpids(
-            PROC_ALL_PIDS,
-            0,
-            pids.as_mut_ptr().cast::<libc::c_void>(),
-            buf_bytes_i32,
-        );
-        let written_usize = usize::try_from(written).ok().filter(|&n| n > 0)?;
-        let actual = written_usize / std::mem::size_of::<libc::pid_t>();
-        pids.truncate(actual);
-        Some(pids)
-    }
-}
-
-/// Read a PID's binary path via `libc::proc_pidpath` and return it
-/// lowercased for case-insensitive substring matching.
-fn pid_path_lower(pid: libc::pid_t) -> Option<String> {
-    if pid <= 0 {
-        return None;
-    }
-    let mut path_buf = vec![0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
-    // SAFETY: proc_pidpath writes into a buffer we provide; we pass the
-    // exact buffer size.
-    #[allow(unsafe_code)]
-    unsafe {
-        let Ok(buf_size_u32) = u32::try_from(path_buf.len()) else {
-            return None;
-        };
-        let len = libc::proc_pidpath(
-            pid,
-            path_buf.as_mut_ptr().cast::<libc::c_void>(),
-            buf_size_u32,
-        );
-        let len_usize = usize::try_from(len).ok().filter(|&n| n > 0)?;
-        path_buf.truncate(len_usize);
-    }
-    String::from_utf8(path_buf).ok().map(|s| s.to_lowercase())
 }
 
 /// find the PID with `sock_path` open as a unix domain

--- a/crates/vortix/src/vortix_platform_macos/route_table.rs
+++ b/crates/vortix/src/vortix_platform_macos/route_table.rs
@@ -18,9 +18,9 @@
 //! probe return their physical interface even while the VPN is up; that
 //! case is rare enough to accept as a known limitation.
 
-use std::sync::{Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use crate::platform::route_probe::{ProbeOutcome, RouteProbe};
 use crate::vortix_core::ports::route_table::RouteTable;
 use crate::vortix_process::CommandSpec;
 
@@ -32,7 +32,7 @@ use crate::vortix_process::CommandSpec;
 /// macOS).
 const ROUTE_QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 
-/// Process-wide backoff state for the route-default probe. Without this,
+/// Process-wide backoff for the route-default probe. Without this,
 /// the scanner thread and network-monitor thread each call this
 /// subprocess every 1-2 seconds; on a broken VPN both hit the 1s
 /// timeout, burning two tokio runtime workers continuously even though
@@ -40,38 +40,7 @@ const ROUTE_QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 /// and prevents the scanner's per-tick budget from being eaten by
 /// hopeless probes, which is what makes the UI feel stuttery (the
 /// scanner ticks at 1Hz so state updates land slow).
-struct ProbeBackoff {
-    /// Number of consecutive subprocess failures (timeout / I/O error).
-    /// Reset to zero on success.
-    consecutive_fails: u32,
-    /// Earliest moment the next probe is allowed. `Instant::now()` or
-    /// earlier = probe immediately; in the future = skip.
-    next_allowed: Instant,
-}
-
-fn backoff_state() -> &'static Mutex<ProbeBackoff> {
-    static STATE: OnceLock<Mutex<ProbeBackoff>> = OnceLock::new();
-    STATE.get_or_init(|| {
-        Mutex::new(ProbeBackoff {
-            consecutive_fails: 0,
-            next_allowed: Instant::now(),
-        })
-    })
-}
-
-/// Map consecutive-failure count to the cooldown that follows. Tuned to
-/// degrade gracefully: a transient kernel-transition (1-2 failures)
-/// recovers immediately; a persistent broken-network state (many
-/// failures) backs off to ~once-per-minute.
-fn cooldown_for_fails(fails: u32) -> Duration {
-    let secs = match fails {
-        0..=2 => 0,
-        3..=5 => 5,
-        6..=10 => 15,
-        _ => 60,
-    };
-    Duration::from_secs(secs)
-}
+static ROUTE_PROBE: RouteProbe = RouteProbe::new();
 
 /// Public-internet probe target. See module-level docs for why this is
 /// preferred over `route get default`.
@@ -98,55 +67,30 @@ impl RouteTable for MacRouteTable {
 /// Returns `None` if the subprocess fails (binary missing, non-zero exit,
 /// I/O error) so callers can degrade gracefully without panicking.
 fn run_route_get_default() -> Option<String> {
-    // Backoff gate — if a recent probe failed badly enough, skip this
-    // call. Callers tolerate `None`; the registry continues serving its
-    // last-known cached route iface, and the scanner thread is freed to
-    // do useful session work instead of waiting on a kernel that can't
-    // answer.
-    {
-        let state = backoff_state()
-            .lock()
-            .expect("backoff state mutex poisoned");
-        if Instant::now() < state.next_allowed {
-            return None;
-        }
-    }
-
-    let result = crate::vortix_process::run_to_output(
+    match ROUTE_PROBE.run(
         CommandSpec::oneshot(
             "route",
             vec!["-n".into(), "get".into(), ROUTE_PROBE_TARGET.into()],
         )
         .timeout(ROUTE_QUERY_TIMEOUT),
-    );
-
-    let mut state = backoff_state()
-        .lock()
-        .expect("backoff state mutex poisoned");
-    if let Ok(output) = result {
-        // Subprocess returned (even with non-zero exit). Reset
-        // backoff so the next caller probes immediately — the kernel
-        // is answering again.
-        state.consecutive_fails = 0;
-        state.next_allowed = Instant::now();
-        return Some(String::from_utf8_lossy(&output.stdout).into_owned());
+    ) {
+        ProbeOutcome::Success(stdout) => Some(stdout),
+        ProbeOutcome::BackedOff => None,
+        ProbeOutcome::Failed {
+            consecutive_failures,
+            cooldown,
+        } => {
+            if consecutive_failures == 1 || cooldown >= Duration::from_secs(5) {
+                tracing::warn!(
+                    target: "vortix::vortix_platform_macos::route_table",
+                    consecutive_fails = consecutive_failures,
+                    cooldown_secs = cooldown.as_secs(),
+                    "`route get default` probe failed; backing off to spare the tokio runtime"
+                );
+            }
+            None
+        }
     }
-    // Timeout or I/O error. Bump the fail counter and push the
-    // next-allowed time out. Emit a tracing warn so operators
-    // investigating "vortix feels slow" via
-    // `RUST_LOG=vortix::vortix_platform_macos=warn` see the backoff active.
-    state.consecutive_fails = state.consecutive_fails.saturating_add(1);
-    let cooldown = cooldown_for_fails(state.consecutive_fails);
-    state.next_allowed = Instant::now() + cooldown;
-    if state.consecutive_fails == 1 || cooldown >= Duration::from_secs(5) {
-        tracing::warn!(
-            target: "vortix::vortix_platform_macos::route_table",
-            consecutive_fails = state.consecutive_fails,
-            cooldown_secs = cooldown.as_secs(),
-            "`route get default` probe failed; backing off to spare the tokio runtime"
-        );
-    }
-    None
 }
 
 /// Extract the `gateway:` line from `route get default` output.
@@ -242,23 +186,5 @@ destination: default
     fn parse_gateway_still_works_on_sample() {
         assert_eq!(parse_gateway(SAMPLE_WIFI), Some("192.168.1.1".into()));
         assert_eq!(parse_gateway(SAMPLE_VPN), Some("10.0.0.1".into()));
-    }
-
-    /// Backoff ladder: the first two failures retry immediately so a
-    /// transient kernel-transition recovers fast. Persistent failures
-    /// escalate to ~once-per-minute so a broken VPN doesn't keep the
-    /// scanner and network-monitor threads burning a tokio worker each.
-    #[test]
-    fn cooldown_ladder_escalates_then_caps() {
-        assert_eq!(cooldown_for_fails(0), Duration::ZERO);
-        assert_eq!(cooldown_for_fails(1), Duration::ZERO);
-        assert_eq!(cooldown_for_fails(2), Duration::ZERO);
-        assert_eq!(cooldown_for_fails(3), Duration::from_secs(5));
-        assert_eq!(cooldown_for_fails(5), Duration::from_secs(5));
-        assert_eq!(cooldown_for_fails(6), Duration::from_secs(15));
-        assert_eq!(cooldown_for_fails(10), Duration::from_secs(15));
-        assert_eq!(cooldown_for_fails(11), Duration::from_secs(60));
-        // Saturates: no further escalation beyond the 60s cap.
-        assert_eq!(cooldown_for_fails(1_000_000), Duration::from_secs(60));
     }
 }

--- a/crates/vortix/src/vortix_platform_windows/interface.rs
+++ b/crates/vortix/src/vortix_platform_windows/interface.rs
@@ -10,10 +10,6 @@ use crate::vortix_core::ports::interface::Interface;
 pub struct WindowsInterface;
 
 impl Interface for WindowsInterface {
-    fn check_wireguard_interface(_name: &str) -> bool {
-        false
-    }
-
     fn resolve_wireguard_interface(_name: &str) -> Option<String> {
         None
     }

--- a/crates/vortix/src/vortix_process/mod.rs
+++ b/crates/vortix/src/vortix_process/mod.rs
@@ -1,8 +1,8 @@
 //! `vortix-process`: concrete `CommandRunner` implementations.
 //!
-//! Owns the tokio + tracing dependency surface. Exposes `CommandRunner` as an
-//! `enum_dispatch`-driven enum carrying `Real(RealRunner)` and `Mock(MockRunner)`
-//! variants. Callers hold the enum by value; static dispatch, no `Box<dyn>`.
+//! Owns the tokio + tracing dependency surface. Exposes `CommandRunner` as a
+//! hand-dispatched enum carrying `Real(RealRunner)` and `Mock(MockRunner)`
+//! variants. Callers hold the enum by value; no `Box<dyn>`.
 //!
 
 #![allow(clippy::missing_errors_doc)]
@@ -167,6 +167,13 @@ pub fn run_to_output(spec: CommandSpec) -> std::io::Result<std::process::Output>
         ))),
         Err(ProcessError::IoError { source, .. }) => Err(source),
     }
+}
+
+/// Run a simple unprivileged command and discard invocation errors.
+#[must_use]
+pub fn simple_output(program: &str, args: &[&str]) -> Option<std::process::Output> {
+    let args = args.iter().map(|arg| (*arg).to_string()).collect();
+    run_to_output(CommandSpec::oneshot(program, args)).ok()
 }
 
 fn outcome_to_output(outcome: CommandOutcome) -> std::process::Output {

--- a/crates/vortix/src/vortix_process/real.rs
+++ b/crates/vortix/src/vortix_process/real.rs
@@ -80,7 +80,7 @@ impl RealRunner {
     }
 
     fn check_privilege(spec: &CommandSpec) -> Result<(), ProcessError> {
-        if spec.requires_privilege == PrivilegeReq::Root && !is_root() {
+        if spec.requires_privilege == PrivilegeReq::Root && !crate::utils::is_root() {
             return Err(ProcessError::PrivilegeDenied {
                 program: spec.program.clone(),
             });
@@ -308,21 +308,6 @@ impl Trait for RealRunner {
         drop(child);
 
         Ok(DetachedHandle { pid, spawned_at })
-    }
-}
-
-fn is_root() -> bool {
-    #[cfg(unix)]
-    {
-        // SAFETY: `geteuid` is a thread-safe getter with no side effects.
-        #[allow(unsafe_code)]
-        unsafe {
-            libc::geteuid() == 0
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        false
     }
 }
 

--- a/crates/vortix/src/vortix_protocol_openvpn/tunnel.rs
+++ b/crates/vortix/src/vortix_protocol_openvpn/tunnel.rs
@@ -17,7 +17,7 @@ use crate::vortix_core::ports::tunnel::{
     ParseError, ParsedProfile, ProtocolStatus, Tunnel, TunnelCapabilities, TunnelError,
     TunnelHandle, TunnelKindTag, TunnelStatus,
 };
-use crate::vortix_core::profile::Profile;
+use crate::vortix_core::profile::{sanitize_profile_name, Profile};
 use crate::vortix_process::{CommandSpec, PrivilegeReq};
 use tracing::{debug, info, warn};
 
@@ -389,20 +389,6 @@ impl ProtocolStatus for OvpnStatus {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
-}
-
-/// Filesystem-safe version of a profile name (matches the binary-side
-/// `utils::sanitize_profile_name` rules).
-fn sanitize_profile_name(name: &str) -> String {
-    name.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
 }
 
 #[allow(clippy::too_many_lines)]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-thiserror = { workspace = true }
 ignore = "0.4"
 
 [lints]


### PR DESCRIPTION
## What does this PR do?

Reduces the runtime's maintenance surface without removing features. Profile lifecycle operations, route-probe backoff, command execution, process discovery, root checks, CIDR policy, sanitization, and home resolution now each have one owner.

The scanner avoids redundant WireGuard and OpenVPN probes, while `dirs`, `enum_dispatch`, and xtask’s unused `thiserror` dependency are removed. The code-only diff removes 475 net lines while preserving architectural boundaries.

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [x] 🔧 Refactor
- [ ] 🧪 Tests

## Checklist

- [x] I ran `cargo fmt`
- [x] I ran `cargo clippy` with no warnings
- [x] I ran `cargo test` and all tests pass
- [x] I updated documentation if needed

Additional validation: workspace check, rustdoc with warnings denied, and all architecture checks pass.
