### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,4 +805,4 @@ nix develop
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Harry-kp/vortix&type=Date)](https://star-history.com/#Harry-kp/vortix&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Harry-kp/vortix&type=Date)](https://star-history.dera.page/#Harry-kp/vortix&Date)


### PR DESCRIPTION
The Star History chart in the README is currently broken: the upstream service cannot reliably fetch stargazer data anymore due to GitHub API restrictions. This switches the chart image and link to a working mirror of the same project so the graph renders again. No other changes.