### PR TITLE
docs: make README a concise project entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,49 +2,42 @@
 
 [![Test](https://github.com/Harry-kp/vortix/actions/workflows/test.yml/badge.svg)](https://github.com/Harry-kp/vortix/actions/workflows/test.yml)
 [![Lint](https://github.com/Harry-kp/vortix/actions/workflows/lint.yml/badge.svg)](https://github.com/Harry-kp/vortix/actions/workflows/lint.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Harry-kp/vortix/blob/main/LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/Harry-kp/vortix/blob/main/CONTRIBUTING.md)
 [![Crates.io](https://img.shields.io/crates/v/vortix.svg)](https://crates.io/crates/vortix)
-[![Crates.io Downloads](https://img.shields.io/crates/d/vortix.svg)](https://crates.io/crates/vortix)
-[![npm](https://img.shields.io/npm/v/@harry-kp/vortix?logo=npm)](https://www.npmjs.com/package/@harry-kp/vortix)
-[![npm Downloads](https://img.shields.io/npm/dm/@harry-kp/vortix?label=npm%20downloads)](https://www.npmjs.com/package/@harry-kp/vortix)
 [![Homebrew](https://img.shields.io/badge/Homebrew-tap-orange?logo=homebrew)](https://github.com/Harry-kp/homebrew-tap)
-[![Nix Flake](https://img.shields.io/badge/Nix-flake-blue?logo=nixos)](https://github.com/Harry-kp/vortix#installation)
+[![Arch Linux](https://img.shields.io/badge/Arch_Linux-extra-1793D1?logo=archlinux&logoColor=white)](https://archlinux.org/packages/extra/x86_64/vortix/)
 [![macOS](https://img.shields.io/badge/macOS-000000?logo=apple&logoColor=white)](https://github.com/Harry-kp/vortix)
 [![Linux](https://img.shields.io/badge/Linux-FCC624?logo=linux&logoColor=black)](https://github.com/Harry-kp/vortix)
-[![Rust](https://img.shields.io/badge/Rust-1.85+-orange?logo=rust)](https://www.rust-lang.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Harry-kp/vortix/blob/main/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/Harry-kp/vortix?style=social)](https://github.com/Harry-kp/vortix)
-[![GitHub Sponsors](https://img.shields.io/github/sponsors/Harry-kp?logo=github)](https://github.com/sponsors/Harry-kp)
-[![X (Twitter)](https://img.shields.io/badge/X-%40Harshitc007-000000?logo=x&logoColor=white)](https://x.com/Harshitc007)
 
-Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding.
+Terminal UI for WireGuard and OpenVPN with multi-tunnel control, real-time telemetry, and leak guarding.
 
 ![Vortix Demo](https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/demo.gif)
 
 <details>
-<summary><b>More scenarios — click to expand</b></summary>
+<summary><strong>See multi-connection, leak detection, split-tunnel, and profile-management demos</strong></summary>
 
 <br>
 
 <table>
   <tr>
     <td align="center" width="50%" valign="top">
-      <b>multi-connection</b><br>
-      <img src="https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/multi-connection.gif" alt="multi-connection demo" />
+      <b>Multi-connection</b><br>
+      <img src="https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/multi-connection.gif" alt="Vortix multi-connection demo" />
     </td>
     <td align="center" width="50%" valign="top">
-      <b>leak detection</b><br>
-      <img src="https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/leak-detection.gif" alt="leak detection demo" />
+      <b>Leak detection</b><br>
+      <img src="https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/leak-detection.gif" alt="Vortix leak-detection demo" />
     </td>
   </tr>
   <tr>
     <td align="center" width="50%" valign="top">
-      <b>split tunnel</b><br>
-      <img src="https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/split-tunnel.gif" alt="split tunnel demo" />
+      <b>Split tunnel</b><br>
+      <img src="https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/split-tunnel.gif" alt="Vortix split-tunnel demo" />
     </td>
     <td align="center" width="50%" valign="top">
-      <b>profile management</b><br>
-      <img src="https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/profile-management.gif" alt="profile management demo" />
+      <b>Profile management</b><br>
+      <img src="https://raw.githubusercontent.com/Harry-kp/vortix/main/assets/profile-management.gif" alt="Vortix profile-management demo" />
     </td>
   </tr>
 </table>
@@ -53,783 +46,164 @@ Terminal UI for WireGuard and OpenVPN with real-time telemetry and leak guarding
 
 ## Why Vortix?
 
-I wanted a single interface to:
-- See connection status, throughput, and latency at a glance
-- Detect IPv6 exposure and verify that system DNS is routed through the VPN
-- Switch between VPN profiles without remembering CLI flags
+Vortix gives WireGuard and OpenVPN users one keyboard-driven view of their tunnels and the network around them. It is useful when plain `wg-quick` or `openvpn` provides too little visibility, while a full desktop VPN client is too heavy or tied to one provider.
 
-Existing options (`wg show`, NetworkManager, Tunnelblick) either lack real-time telemetry or require a GUI.
+- Connect multiple profiles and distinguish the default-route tunnel from split-route tunnels.
+- See throughput, latency, jitter, packet loss, exit identity, DNS policy, and encryption state.
+- Detect IPv4, IPv6, and DNS-policy exposure instead of assuming a successful handshake means traffic is protected.
+- Control the same engine from the TUI, CLI, or versioned JSON output.
+- Work locally, over SSH, and across macOS and Linux.
 
-| Feature | Vortix | GUI Clients | CLI-only |
-|---------|:------:|:-----------:|:--------:|
-| Memory usage | ~15MB | 200-500MB | ~5MB |
-| Startup time | <100ms | 2-5s | Instant |
-| Real-time telemetry | ✅ | ✅ | ❌ |
-| Leak detection | ✅ | Some | ❌ |
-| Kill switch | ✅ | ✅ | Manual |
-| Keyboard-driven | ✅ | ❌ | ✅ |
-| Works over SSH | ✅ | ❌ | ✅ |
+Vortix orchestrates the system `wg`, `wg-quick`, and `openvpn` implementations; it does not implement either VPN protocol itself.
 
-### Compared to specific tools
+## Quick start
 
-| Tool | Protocols | TUI | Leak detection | Multi-tunnel | Cross-platform |
-|---|---|:-:|:-:|:-:|:-:|
-| **Vortix** | WireGuard + OpenVPN | ✅ | IPv4 / IPv6 / DNS | ✅ | macOS, Linux |
-| `wg-quick` / `wg show` | WireGuard only | ❌ | ❌ | manual | Linux + macOS |
-| NetworkManager-gnome | Both (via plugins) | ❌ (GUI) | ❌ | one default | Linux only |
-| Tunnelblick | OpenVPN only | ❌ (GUI) | ❌ | ❌ | macOS only |
-| WireGuard.app (menu bar) | WireGuard only | ❌ (GUI) | ❌ | switch only | macOS / Windows |
-| Mullvad app | Provider-locked | ❌ (GUI) | provider's own | ❌ | macOS, Linux, Windows |
+Install the protocol tools first:
 
-Use the right tool: if you only run one WireGuard tunnel and don't care about telemetry, plain `wg-quick` is the lightest option. If you're locked into a single VPN provider's app, you don't need Vortix. If you want a unified TUI across multiple profiles, both protocols, and active leak detection — that's the gap Vortix fills.
-
-## Features
-
-- **WireGuard & OpenVPN** — Auto-detects `.conf` and `.ovpn` files
-- **Multi-tunnel** *(new in v0.4.0)* — Multiple VPN profiles connected simultaneously; the registry tracks primary + addressable secondaries; per-profile retry/auto-reconnect; auto-adopt of externally-started tunnels (`wg-quick up X` from another terminal shows up in the TUI within ~1s)
-- **Advanced Telemetry** — Real-time throughput, latency, **jitter**, and **packet loss**
-- **Geo-Location** — Instant detection of your exit IP's city and country
-- **Leak detection** — Monitors IPv4/IPv6 exposure and verifies the active system DNS policy plus each resolver's kernel route
-- **Kill Switch** — Platform-native firewall (PF on macOS; `iptables` or `nftables` on Linux). Three modes — **Off** (no firewall), **Block on drop** (engages only if the VPN drops unexpectedly), **VPN-only** (firewall stays engaged whether the VPN is up or down — closes the gap-between-drop-and-reconnect leak window). Multi-tunnel-aware: every active tunnel's interface is allow-listed. Rules survive vortix restarts and crashes but not an OS reboot — re-arm after boot
-- **Session event journal** *(v0.3.0)* — JSONL event log per session under `${XDG_DATA_HOME}/vortix/sessions/`, 30-day retention; useful for diagnostics and scripting
-- **Per-process socket audit** *(v0.3.0)* — `vortix audit` answers "is this traffic actually routing through the tunnel?" with per-PID socket inventory; Linux + macOS supported
-- **Versioned structured output** *(v0.3.0)* — every `--json` envelope carries a `schema_version` field (currently `2`) so consumers can detect breaking changes instead of finding them at runtime
-- **Interactive Import** — Easily add new profiles directly within the TUI
-- **Config Viewer** — Inspect profile configurations directly within the TUI
-- **Keyboard-driven** — No mouse required
-
-## Platform Support
-
-Vortix is actively developed and used primarily on macOS.
-
-Linux support is a current focus and is improving quickly, with CI coverage for Ubuntu and Fedora. Linux environments still vary a lot across distributions, firewall backends, DNS tooling, and privilege models, so distro-specific issues may still exist.
-
-If you use Vortix on Linux and hit a problem, please open an issue and include `vortix report` output when possible. Ubuntu, Fedora, and Arch users are especially helpful when testing release candidates and validating fixes before release. If you want to help test Linux support, join the [Linux tester discussion](https://github.com/Harry-kp/vortix/discussions/184).
-
-## Requirements
-
-### Runtime dependencies
-
-| Dependency | macOS | Linux | Purpose |
-|------------|-------|-------|---------|
-| `openvpn` | `brew install openvpn` | `apt install openvpn` | OpenVPN sessions |
-| `wireguard-tools` | `brew install wireguard-tools` | `apt install wireguard-tools` | WireGuard sessions |
-| `resolvconf` / `systemd-resolved` | N/A (uses native DNS) | Auto-detected; see DNS note below | WireGuard DNS management (only on non-resolved hosts) |
-| `iptables` or `nftables` | N/A (uses `pfctl`) | Pre-installed | Kill switch |
-
-> Vortix checks for missing tools at startup and shows a warning toast with install instructions.
-> Interface inspection, network stats, DNS detection, HTTP telemetry, ICMP latency, and clipboard handoff now run in-process — no `curl`, `ping`, `which`, `ifconfig`, `ip addr`, `ps`, `netstat`, `lsof`, `scutil`, `pbcopy`, or `xclip` shell-out required.
-
-**DNS tools note:** If your WireGuard profile includes a `DNS =` directive, Vortix manages per-link DNS itself:
-- **systemd-resolved hosts (Arch / Omarchy, NixOS with `services.resolved.enable = true`, default Fedora Workstation):** no extra package required. Vortix calls `resolvectl` (shipped with systemd) to register the tunnel's DNS server on the kernel interface. The legacy `systemd-resolvconf` / `openresolv` shim is no longer needed on these distros.
-- **Non-resolved Linux (Debian/Ubuntu without resolved, etc.):** Vortix falls back to `wg-quick`'s built-in `resolvconf` path — install `openresolv` if your distro doesn't ship one (`sudo apt install openresolv`).
-- **Alpine/Void (OpenRC):** `/etc/resolv.conf` editing as the universal fallback.
-
-### Build dependencies (source installs only)
-
-- Rust 1.85+ (for `edition2024` transitive deps; distros shipping older Rust — e.g. Ubuntu 24.04's apt — will need `rustup` for source builds)
-- macOS 12+ or Linux kernel 3.10+ (5.6+ recommended for native WireGuard)
-
-### Quick install commands
-
-**Ubuntu/Debian:**
 ```bash
-sudo apt install wireguard-tools openvpn iptables systemd-resolved
+# macOS
+brew install wireguard-tools openvpn
+
+# Ubuntu / Debian
+sudo apt install wireguard-tools openvpn
+
+# Fedora
+sudo dnf install wireguard-tools openvpn
 ```
 
-**Fedora/RHEL:**
+Then install Vortix using your preferred channel:
+
+| Channel | Install |
+|---|---|
+| Homebrew | `brew install Harry-kp/tap/vortix` |
+| Arch Linux | `sudo pacman -S vortix` |
+| Cargo | `cargo install vortix` |
+| npm | `npm install -g @harry-kp/vortix` |
+| Nix | `nix profile install github:Harry-kp/vortix` |
+| Shell installer | `curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Harry-kp/vortix/releases/latest/download/vortix-installer.sh \| sh` |
+| Static Linux binary | Download the musl archive from [Releases](https://github.com/Harry-kp/vortix/releases) |
+
+Import a profile and connect:
+
 ```bash
-sudo dnf install wireguard-tools openvpn iptables systemd-resolved
+vortix import ./work.conf       # .conf, .ovpn, URL, or directory
+sudo vortix                    # interactive dashboard
+
+# Or stay in the CLI
+sudo vortix up work
+vortix status
+sudo vortix down work
 ```
 
-**Arch Linux** (only needed for source builds — `pacman -S vortix` handles deps automatically):
-```bash
-sudo pacman -S wireguard-tools openvpn iptables
-```
+Tunnel and firewall changes require root. Read-only commands such as `list`, `show`, and `status` do not. If `sudo vortix` cannot find a Cargo-installed binary on Linux, link it once with `sudo ln -s ~/.cargo/bin/vortix /usr/local/bin/vortix`.
 
-> **DNS management:** When your WireGuard profile contains `DNS =`, Vortix detects systemd-resolved and registers per-link DNS via `resolvectl` directly (no `systemd-resolvconf` / `openresolv` shim required). On non-resolved Linux Vortix falls back to `wg-quick`'s built-in `resolvconf` path; install `openresolv` if your distro doesn't ship one. Non-systemd distros (Alpine, Void, Gentoo OpenRC) use `/etc/resolv.conf` editing.
+See the [usage guide](https://github.com/Harry-kp/vortix/blob/main/docs/usage.md) for command and keybinding references.
 
-## Installation
+## Highlights
 
-Pick the method that matches how you usually install CLI tools.
+| Area | What Vortix provides |
+|---|---|
+| Protocols | WireGuard `.conf` and OpenVPN `.ovpn` / `.conf` profiles |
+| Multi-tunnel | Concurrent tunnels, default-route ownership, split routes, conflict checks, and per-profile state |
+| Telemetry | Throughput, latency, jitter, packet loss, public IP, ISP, and location |
+| Security Guard | IPv4/IPv6 exposure, active DNS policy, encryption posture, and kill-switch state |
+| Kill switch | `off`, `block-on-drop`, and `vpn-only`, using PF on macOS or nftables/iptables on Linux |
+| Automation | Human output, a versioned JSON envelope, NDJSON watch streams, and shell completions |
+| Diagnostics | Event logs, session journals, per-process socket audit, and `vortix report` |
+| Appearance | Seven built-in themes, including terminal-native light/dark colors |
 
-| Channel | OS | Install | Upgrade | Uninstall |
-|---|---|---|---|---|
-| **Homebrew** | macOS / Linux | `brew install Harry-kp/tap/vortix` | `brew upgrade vortix` | `brew uninstall vortix` |
-| **pacman** ([Arch extra](https://archlinux.org/packages/extra/x86_64/vortix/)) | Arch Linux | `sudo pacman -S vortix` | `sudo pacman -Syu vortix` | `sudo pacman -R vortix` |
-| **cargo** | Any | `cargo install vortix` | `cargo install vortix --force` | `cargo uninstall vortix` |
-| **npm** | Any | `npm i -g @harry-kp/vortix` | `npm i -g @harry-kp/vortix@latest` | `npm uninstall -g @harry-kp/vortix` |
-| **npx** *(no install)* | Any | `npx @harry-kp/vortix` | — (always latest) | — |
-| **Shell installer** | macOS / Linux | `curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Harry-kp/vortix/releases/latest/download/vortix-installer.sh \| sh` | re-run the curl command | `rm $(which vortix)` |
-| **Nix flake** | Any with Nix | `nix profile install github:Harry-kp/vortix` (or `nix run github:Harry-kp/vortix` to run without installing) | `nix profile upgrade vortix` | `nix profile remove vortix` |
-| **Static binary** | Linux (any libc) | Download `vortix-x86_64-unknown-linux-musl.tar.xz` from [releases](https://github.com/Harry-kp/vortix/releases) and place on `$PATH` | re-download | `rm /path/to/vortix` |
-| **From source** | Any | `git clone https://github.com/Harry-kp/vortix.git && cd vortix && cargo install --path .` | `git pull && cargo install --path . --force` | `cargo uninstall vortix` |
+## Platform support
 
-> The static-binary build needs no glibc but still needs the runtime dependencies above (`openvpn`/`wireguard-tools` and the kill-switch tools).
+| | macOS | Linux |
+|---|---|---|
+| VPN tools | Homebrew `wireguard-tools`, `openvpn` | Distribution `wireguard-tools`, `openvpn` |
+| Kill switch | PF (`pfctl`) | nftables or iptables |
+| DNS integration | System Configuration | systemd-resolved, NetworkManager, resolvconf, or `/etc/resolv.conf` fallback |
+| CI coverage | macOS | Ubuntu and Fedora |
 
-### Linux: setting up sudo access
+macOS is the primary development platform. Linux is tested continuously, but distributions vary in resolver, firewall, kernel, and privilege configuration. Reports from other distributions are valuable—include `vortix report` when possible.
 
-Vortix needs root to manage VPN connections and firewall rules. On Linux, `sudo` uses a restricted PATH (`secure_path` in `/etc/sudoers`) that **does not include** `~/.cargo/bin/` — so `sudo vortix` will fail with `command not found`.
-
-**Fix (one-time):**
-```bash
-sudo ln -s ~/.cargo/bin/vortix /usr/local/bin/vortix
-```
-
-After this, `sudo vortix` works as expected.
-
-**Who is affected:**
-- `cargo install vortix` — yes
-- Shell installer (`curl | sh`) — yes
-- From source (`cargo install --path .`) — yes
-- `pacman -S vortix` (Arch) — **no**, installs to `/usr/bin/`
-- `brew install` (Homebrew) — **no**, installs to Homebrew prefix
-- `npm install -g` (npm) — **no**, installs to npm global bin
-- Nix (`nix profile install`) — **no**, installs to Nix profile bin
-- macOS — **no**, sudo preserves user PATH
-
-### Linux support note
-
-Most day-to-day development happens on macOS. Linux support is continuously tested in CI, but real-world distro coverage is still growing. If something behaves differently on your Linux setup, please treat that as useful signal and report it rather than assuming it is expected.
+Source builds require Rust 1.85 or newer. Linux kernel 5.6 or newer is recommended for native WireGuard.
 
 ## Security model
 
-Vortix asks for root because managing VPN tunnels and firewall state is privileged on every supported OS. Here's the short list of what it actually does with that privilege:
+Vortix runs privileged only because tunnel, route, DNS, and firewall mutation require it. The privileged path is intentionally narrow:
 
-- **What it reads:** profile files (`~/.config/vortix/profiles/*`), kernel network state (`getifaddrs`, `sysctl` route table, `wg show`, `openvpn` management socket).
-- **What it writes:** kernel tunnel interfaces via `wg-quick` / `openvpn`; the platform firewall (`pfctl` on macOS, `iptables` / `nftables` on Linux) for the kill switch; tiny config-dir files (`real-ip.cache`, `real-ipv6.cache`, log + journal under `${XDG_DATA_HOME}/vortix/`, mode 0600).
-- **What it does NOT touch:** the bootloader, system services, package manager state, `/etc/` outside `/etc/wireguard` (managed by `wg-quick`), other users' files, your shell history, your keychain, any cloud account.
-- **Network egress:** ipinfo.io and ifconfig.co for IP / geo probes. DNS protection is checked locally by exact operating-system resolver readback and kernel route inspection; Vortix sends no DNS-test telemetry to its own infrastructure because there is no Vortix infrastructure.
+- Protocol execution stays in protocol-specific adapters around the installed `wg`, `wg-quick`, and `openvpn` binaries.
+- Platform adapters own firewall, DNS, route, and kernel inspection behavior.
+- Profile identity, process ownership, durable operations, and read-back checks fail closed when Vortix cannot prove the state it is managing.
+- Sensitive profile and credential material is bounded, owner-checked, and kept out of normal logs and JSON output.
+- Telemetry uses public IP/geolocation providers; Vortix has no hosted control plane or DNS-test service.
 
-Code that runs as root is in `crates/vortix/src/vortix_platform_*` (per-OS firewall + DNS) and `crates/vortix/src/vortix_protocol_*` (subprocess wrappers for `wg`, `wg-quick`, `openvpn`). Both modules are kept thin so the privileged surface is small and reviewable. Tunnel binaries (`wg-quick`, `openvpn`) are the same ones a hand-rolled `sudo wg-quick up …` would invoke; vortix doesn't ship its own VPN implementation.
+Kill-switch rules survive a Vortix restart within the same boot, but the OS may flush them during reboot. Re-arm `vpn-only` after each boot.
 
-## Usage
+For the trust boundaries and threat analysis, read the [privileged-helper threat model](https://github.com/Harry-kp/vortix/blob/main/docs/security/privileged-helper-threat-model.md).
 
-Vortix has two modes: an interactive TUI dashboard (default) and a headless CLI for scripting, automation, and AI agents.
+## Command overview
 
-```bash
-sudo vortix              # Launch TUI dashboard (default)
+```text
+vortix import <PATH|URL>       Add one profile or a directory
+vortix list                    List profiles
+vortix show <PROFILE>          Inspect a profile with secrets masked
+sudo vortix up <PROFILE>       Connect
+sudo vortix down [PROFILE]     Disconnect one or every active tunnel
+sudo vortix reconnect [NAME]   Reconnect one or every active tunnel
+vortix status [--watch]        Show or stream state
+vortix killswitch [MODE]       Inspect or set off/block-on-drop/vpn-only
+vortix audit                   Inspect process sockets and tunnel routing
+vortix report                  Generate diagnostics for a bug report
 ```
 
-### Standard and Background modes
-
-Vortix starts in **Standard mode** with no always-on Vortix control service
-while idle. Optional **Background mode** adds routine control without `sudo`
-after one-time setup, live CLI/TUI synchronization, automatic drop recovery,
-boot connections, and continuous policy verification by running persistent
-Vortix processes. Declining setup removes no Standard-mode feature.
-
-This preparatory release exposes `vortix setup` and `vortix background
-{status,recover,diagnostics,disable}` for review. Confirmed setup, recovery,
-and disable requests return the nonzero `background_activation_unavailable`
-error and run no privileged process until enrollment is activated. Diagnostics
-remain bounded/redacted; fallback data is visibly unauthenticated and cannot
-establish authority or protection. `background diagnostics --follow --json`
-is an NDJSON stream and emits only newly observed records after its initial
-snapshot. Boot preflight rejects parser-identified interactive OpenVPN
-profiles and fails closed on external OpenVPN key/PKCS#12 material before
-saving intent.
-
-### CLI Commands
-
-Every subcommand supports `--json` for machine-readable output and `--quiet` for silent operation (exit code only).
-
-**Connection (multi-tunnel aware):**
-```bash
-sudo vortix up work-vpn         # Connect to a profile
-sudo vortix up vpn-b --yes      # Bypass the conflict gate (default-route
-                                # takeover / route overlap with another
-                                # active tunnel; non-interactive)
-sudo vortix down                # Disconnect every active tunnel
-sudo vortix down work-vpn       # Disconnect only the named profile
-sudo vortix down --force        # Force-disconnect (SIGKILL)
-sudo vortix reconnect           # Cycle every currently-Connected tunnel
-vortix status                   # Show connection state + telemetry
-vortix status --json            # v2 envelope: data.connections[] +
-                                # data.primary (back-compat data.connection
-                                # populated when exactly one tunnel is up)
-vortix status --brief           # One-line: "● Connected to work-vpn"
-vortix status --watch           # Live updates every 2s
-vortix status --watch --json    # NDJSON stream for monitoring
-```
-
-Multiple tunnels can be active simultaneously. The tunnel that owns the
-kernel default route is the *primary*; secondaries are *addressable*
-(reachable on their declared `AllowedIPs` only). `vortix up B` while
-A is up triggers a conflict gate when both claim the default route or
-when their `AllowedIPs` overlap — pass `--yes` to bypass for scripts.
-
-**Profile Management:**
-```bash
-vortix list                     # List all imported profiles
-vortix list --names-only        # Profile names for scripting
-vortix list --sort last-used    # Most recently used first
-vortix import ./work.conf       # Import a WireGuard profile
-vortix import ./configs/        # Bulk import from directory
-vortix show work-vpn            # Display profile configuration
-vortix show work-vpn --raw      # Raw config file contents
-vortix delete old-vpn --yes     # Delete without confirmation
-vortix rename old-vpn new-vpn   # Rename a profile
-```
-
-**Security:**
-```bash
-# Kill switch — one label per mode, used in the TUI, JSON envelope,
-# CLI input, and CLI output alike.
-#   off             All traffic flows. Real IP exposed if VPN drops.
-#   block-on-drop   Block traffic only if the VPN drops unexpectedly.
-#   vpn-only        Only VPN traffic permitted. No internet without a VPN.
-sudo vortix killswitch off
-sudo vortix killswitch block-on-drop
-sudo vortix killswitch vpn-only
-vortix killswitch               # Show current mode + behaviour
-sudo vortix release-killswitch  # Emergency firewall release
-```
-
-> **Reboot boundary:** kill-switch firewall rules live in the OS firewall
-> (PF / iptables / nftables), which is flushed on reboot. `vpn-only` mode is
-> therefore **not enforced between boot and the next vortix launch** — re-arm
-> it (`sudo vortix killswitch vpn-only`) after restarting. Rules do survive
-> vortix restarts, crashes, and binary upgrades within one boot.
-
-**System:**
-```bash
-vortix info                     # Config paths, versions, profile count
-vortix update                   # Self-update from crates.io
-vortix report                   # Generate bug report
-vortix completions bash >> ~/.bashrc      # Shell completions
-vortix completions zsh > ~/.zfunc/_vortix
-```
-
-**Advanced subcommands (socket audit, daemon):**
-
-```bash
-# Per-process socket audit — "is this traffic actually routing
-# through the tunnel?" Pull-based snapshots; Linux + macOS supported.
-vortix audit                                  # tabular
-vortix audit --json                           # structured envelope
-vortix audit --pid 12345                      # filter to one process
-vortix audit --vpn-only                       # only sockets on the tunnel
-
-# Daemon IPC — host the engine as a long-running process. Wire
-# contract + socket binding + UID-gated accept loop are in place
-# (single-client-at-a-time today; engine routing through the daemon
-# is follow-up work).
-vortix daemon                                 # default socket path
-vortix daemon --socket /tmp/vortix.sock       # custom path
-```
-
-The Engine FSM, JSONL session journal, layered settings, and sidecar
-migration all live behind existing commands — the journal path
-surfaces in `vortix info` output, the migration runs at startup, and
-`settings.toml` works whether or not you ever create one.
-
-See [`docs/MIGRATION.md`](https://github.com/Harry-kp/vortix/blob/main/docs/MIGRATION.md) for the upgrade guide and
-opt-in details on the secret store, journal, and daemon.
-
-**JSON output for AI agents / scripts:**
-```bash
-# Structured JSON envelope on every command
-vortix status --json
-# {"ok":true,"command":"status","data":{...},"next_actions":[...]}
-
-vortix list --json | jq '.data[].name'    # Extract profile names
-
-# NDJSON stream for monitoring
-vortix status --watch --json
-```
-
-**Exit codes** are semantic and scriptable:
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | General error |
-| 2 | Permission denied (needs sudo) |
-| 3 | Not found (profile doesn't exist) |
-| 4 | State conflict (already connected, default-route takeover, route overlap) |
-| 5 | Missing dependency |
-| 6 | Timeout |
-
-### Keybindings
-
-| Key | Action |
-|-----|--------|
-| `Tab` | Cycle Focus (panels). Connection Details mirrors the sidebar selection — switch tunnels by navigating the profile list. |
-| `1-9` | Connect to Quick-Slot 1-9 |
-| `Enter` | Connect / Toggle Profile |
-| `d` | Disconnect focused tunnel (sidebar row, or primary when no sidebar focus) |
-| `D` | Disconnect ALL active tunnels (with confirm when N > 1) |
-| `c` | Cancel an in-flight `Connecting` profile from Connection Details |
-| `r` | Reconnect — cycle every Connected tunnel |
-| `B` | "Both" — from the takeover overlay, connect both tunnels (multi-tunnel) |
-| `i` | Import Profile (Direct) |
-| `v` | View Profile Configuration |
-| `y` | Copy Public IP to Clipboard |
-| `K` | Toggle Kill Switch (Shift+K) |
-| `R` | Rename Profile (Shift+R) |
-| `s` | Cycle Profile Sort Order (Sidebar) |
-| `f` | Flip Panel (Chart / Connection Details / Security) — back face shows alternate view. Inside Event Log, cycles the log-level filter. |
-| `z` | Toggle Zoom View (Panel) |
-| `x` | Open Action Menu (Contextual) |
-| `b` | Open Bulk Menu |
-| `?` | Open Help Overlay (Tab cycles sections) |
-| `Del` | Delete Profile (Sidebar) |
-| `q` | Quit Application |
-
-## Configuration
-
-### Config directory
-
-By default, vortix stores profiles, auth credentials, and logs in `~/.config/vortix/`.
-
-Override via CLI flag or environment variable:
-
-```bash
-sudo vortix --config-dir /path/to/custom/dir
-# or
-export VORTIX_CONFIG_DIR=/path/to/custom/dir
-sudo vortix
-```
-
-Precedence: `--config-dir` flag > `VORTIX_CONFIG_DIR` env var > default path.
-
-When running with `sudo`, vortix automatically resolves the invoking user's home directory (via `SUDO_USER`), so config files live in *your* home, not `/root/`.
-
-### Directory structure
-
-```
-~/.config/vortix/
-├── profiles/                 VPN configuration files
-│   ├── work.conf             WireGuard profile
-│   ├── work.meta.toml        Sidecar metadata (new in v0.3.0; auto-generated)
-│   ├── office.ovpn           OpenVPN profile
-│   └── office.meta.toml      Sidecar metadata (new in v0.3.0; auto-generated)
-├── auth/                     Saved OpenVPN credentials
-│   └── office                Username + password for "office" profile
-├── run/                      OpenVPN runtime files (temporary)
-│   ├── office.pid            Daemon PID (source of truth for disconnect)
-│   └── office.log            Raw daemon output (monitors connect/failure)
-├── logs/                     Application logs (daily rotation)
-│   └── 2026-02-09.log        Same content as the TUI Logs panel
-├── config.toml               User settings (optional, see below)
-├── settings.toml             Figment-layered settings (optional, new in v0.3.0)
-├── metadata.json             Profile metadata (last used, sort order)
-├── killswitch.state          Kill switch state for crash recovery
-└── real-ip.cache             Cached pre-VPN public IP (Security Guard's Real IP row)
-```
-
-Session event journals live in a separate XDG directory because they're observability data, not user config:
-
-```
-${XDG_DATA_HOME}/vortix/sessions/                   (new in v0.3.0)
-├── 2026-...-pid.jsonl        JSONL event log per session
-└── ...                       30-day / 30-file retention
-```
-
-Resolved paths by platform:
-
-- **Linux:** `~/.local/share/vortix/sessions/`
-- **macOS:** `~/Library/Application Support/vortix/sessions/`
-
-Find the current session's path with `vortix info`.
-
-All files and directories under the config dir are owned by your user account, even when vortix runs under `sudo`. You can read, modify, or delete anything here without elevated privileges.
-
-| Path | Mode | Description |
-|------|:----:|-------------|
-| `profiles/` | `600` | Your `.conf` and `.ovpn` files plus the auto-generated `.meta.toml` sidecars (new in v0.3.0). Sidecars are idempotent — delete and they regenerate. |
-| `auth/` | `600` | Saved OpenVPN username/password pairs. One file per profile, written from the TUI's auth prompt or by manual `printf 'user\npass\n' > auth/<profile>.auth`. |
-| `run/` | `644` | **OpenVPN only.** PID and log files created during a VPN session. The `.pid` file identifies which daemon to kill; the `.log` is polled for success/failure. Cleaned up on disconnect. WireGuard doesn't use this. |
-| `logs/` | `644` | Application session logs (daily rotation, configurable size/retention). Not the raw OpenVPN output in `run/`. |
-| `config.toml` | `644` | Optional user settings (legacy). Only exists if you create it manually (see below). |
-| `settings.toml` | `644` | Optional figment-layered settings (new in v0.3.0): defaults → system file → this user file → `VORTIX_*` env vars. Not auto-created. |
-| `metadata.json` | `644` | Internal bookkeeping (last used, sort order). Auto-managed. |
-| `killswitch.state` | `644` | Persists kill switch mode across crashes. Auto-managed. |
-| `real-ip.cache` | `600` | Last-known pre-VPN public IP, written whenever vortix observes you in the un-tunneled state. Loaded on startup so the Security Guard's `Real IP` row populates immediately — including when vortix is opened while a VPN is already up. Two-line plain text (`<ip>\n<unix-timestamp>\n`). Refreshes on any future disconnected sample; stale entries (network moves while vortix is closed) self-correct the next time you disconnect. |
-
-### Config file
-
-Create `~/.config/vortix/config.toml` to customize settings. All fields are optional -- missing fields use defaults:
-
-```toml
-# --- Appearance ---
-
-# Built-ins: "synthwave" (default), "terminal", "catppuccin-mocha",
-# "dracula", "nord", "gruvbox-dark", and "tokyo-night". "terminal"
-# inherits your terminal colors; the others are fixed palettes.
-theme = "synthwave"
-
-# --- Timing ---
-
-# UI refresh rate in milliseconds (default: 1000)
-tick_rate = 1000
-
-# Telemetry polling interval in seconds (default: 30)
-telemetry_poll_rate = 30
-
-# HTTP API timeout in seconds (default: 5)
-api_timeout = 5
-
-# Ping timeout in seconds (default: 2)
-ping_timeout = 2
-
-# OpenVPN connection timeout in seconds (default: 20)
-connect_timeout = 20
-
-# Max seconds to wait for a VPN disconnect before force-killing (default: 30)
-disconnect_timeout = 30
-
-# --- Logging ---
-
-# Minimum log level shown in the TUI event log: "debug", "info", "warning", "error" (default: "info")
-log_level = "info"
-
-# Maximum log entries kept in the TUI event log (default: 1000)
-max_log_entries = 1000
-
-# Log file rotation size in bytes (default: 5242880 = 5 MB)
-log_rotation_size = 5242880
-
-# Days to retain old log files (default: 7)
-log_retention_days = 7
-
-# --- OpenVPN ---
-
-# OpenVPN daemon verbosity level, --verb flag, range 0-11 (default: "3")
-openvpn_verbosity = "3"
-
-# --- Telemetry endpoints ---
-
-# Ping targets for latency measurement (tried in order)
-ping_targets = ["1.1.1.1", "8.8.8.8", "9.9.9.9", "208.67.222.222"]
-
-# IPv6 leak detection endpoints
-ipv6_check_apis = ["https://ipv6.icanhazip.com", "https://v6.ident.me", "https://api6.ipify.org"]
-
-# Primary IP/ISP API
-ip_api_primary = "https://ipinfo.io/json"
-
-# Fallback IP APIs and exact-IP geolocation fallback
-ip_api_fallbacks = ["https://api.ipify.org", "https://icanhazip.com", "https://ifconfig.me/ip"]
-geolocation_api_fallback = "https://ipwho.is"
-```
-
-## How It Works
-
-**Telemetry:** A background thread polls system network stats every second for throughput (macOS: `libc::getifaddrs` reading BSD `if_data`; Linux: `/proc/net/dev`). Network quality (latency, jitter, loss) is measured with a hand-rolled ICMP echo probe over an unprivileged `SOCK_DGRAM` socket (falls back to TCP-connect-to-443 when ICMP is restricted). Public IP, ISP, and geo-location data are fetched via `ureq` over rustls-TLS — no `curl` shell-out, no tokio runtime overhead in the std::thread-based telemetry workers.
-
-**Security (Kill Switch & Leak Detection):**
-- **Kill Switch:** Platform-native firewall integration. macOS uses PF (Packet Filter) via `pfctl`. Linux supports `iptables` (default-DROP OUTPUT policy + explicit ACCEPT rules for loopback / RFC1918 / DHCP / each active tunnel's interface + server IPs, applied via `iptables-restore` for atomic switchover) and `nftables` (atomic `vortix_killswitch` table). Three modes — one label per mode, identical across the TUI, `vortix status` / `vortix killswitch` human output, and the JSON envelope:
-
-  | Label / CLI verb      | Behavior                                                                                                                                                   |
-  | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | **`off`**             | All traffic flows; real IP exposed if VPN drops.                                                                                                           |
-  | **`block-on-drop`**   | Engage default-DROP egress *only* when an active VPN drops unexpectedly.                                                                                   |
-  | **`vpn-only`**        | Default-DROP egress stays engaged whether the VPN is up or down, so the gap between a drop and reconnect can never leak. Canonical Linux killswitch shape. |
-
-  The same three slugs are what you type (`vortix killswitch <slug>`) and what you read back (TUI, `vortix status`, JSON envelope). Multi-tunnel-aware: every Connected tunnel contributes ACCEPT rules; the persisted state survives `vortix` restarts.
-- **IPv6 Leak:** Active monitoring via `api6.ipify.org`. Any IPv6 traffic detected while VPN is active triggers a leak warning.
-- **DNS Leak:** Monitors DNS configuration to ensure nameservers align with the secure tunnel (macOS: `SCDynamicStore` via the `system-configuration` crate; Linux: `resolvectl` / `nmcli` / `/etc/resolv.conf`).
-
-**WireGuard Integration:** macOS resolves interface names via `/var/run/wireguard/*.name`. Linux uses kernel WireGuard interfaces directly (`wg0`, `wg1`, etc.). Both platforms parse `wg show` for handshake timing, transfer stats, and endpoint metadata.
-
-**OpenVPN Integration:** Tracks session uptime and connection status via the macOS/Linux process-listing APIs (`libc::proc_listpids` on macOS, `/proc/<pid>/cmdline` on Linux). Interface detection uses `libc::getifaddrs` on both.
-
-### Platform Notes
-
-| Feature | macOS | Linux |
-|---------|-------|-------|
-| Kill switch | `pfctl` (PF) | `iptables` or `nftables` |
-| Network stats | `libc::getifaddrs` + `if_data` | `/proc/net/dev` |
-| Interface detection | `libc::getifaddrs` + `/var/run/wireguard/` | `libc::getifaddrs` + `/sys/class/net/` + `wg show` |
-| DNS detection | `SCDynamicStore` (SystemConfiguration framework) | `resolvectl`, `nmcli`, `/etc/resolv.conf` |
-| Default VPN iface | `utun0` | `wg0` |
-| Tested distros | macOS 12+ | Ubuntu, Fedora, Arch |
-
-## Troubleshooting
-
-### Quick Reference: Common Errors
-
-| Error Message | Cause | Solution |
-|---------------|-------|----------|
-| `Missing dependencies: resolvconf (systemd)` | WireGuard profile has DNS, systemd-resolved is *not* the resolver, and no `resolvconf` shim is installed. If you're on a resolved host this error no longer fires — vortix routes DNS through `resolvectl` directly. | Run `sudo apt install openresolv` (or your distro's equivalent) **only on non-resolved Linux**. Resolved hosts need no extra package. |
-| `iptables-restore: unable to initialize table` | Cloud kernel doesn't support iptables; profile uses `AllowedIPs = 0.0.0.0/0` | Change `AllowedIPs` to `10.0.0.0/8` or disable kill switch |
-| `wg-quick: The config file must be a valid interface name` | Profile name > 15 characters | Rename: `vortix rename long-name short-name` |
-| `Connection succeeded but no internet` | `AllowedIPs` doesn't include your target | Add target IP to `AllowedIPs` in config |
-| `connection timed out` or `Connection refused` | Can't reach VPN endpoint | Check firewall/cloud provider port restrictions |
-
-### General Issues
-
-**Profiles missing after upgrade (Linux)**
-
-If you previously ran vortix with `sudo` and profiles were stored in `/root/.config/vortix/`, the app will offer a one-time migration prompt. Accept it to move your data to `~/.config/vortix/` under your real user account.
-
-If you declined migration and want to keep using the old path:
-
-```bash
-sudo vortix --config-dir /root/.config/vortix
-```
-
-**Permission denied errors**
-
-If config files are owned by root, fix ownership:
-
-```bash
-sudo chown -R $(whoami) ~/.config/vortix/
-```
-
-### Arch Linux & Distribution-Specific FAQ
-
-#### Q: Connection fails with "Missing dependencies: resolvconf (systemd)"
-
-**A:** Since v0.4 vortix manages per-link DNS via `resolvectl` directly on systemd-resolved hosts — Arch, Omarchy, NixOS with `services.resolved.enable = true`, and default Fedora Workstation no longer need the `systemd-resolvconf` / `openresolv` shim package.
-
-This error now only fires when:
-- Your `.conf` has `DNS = …`, AND
-- systemd-resolved is NOT the host's resolver (or resolved is installed but `resolvectl` itself is broken), AND
-- no working `resolvconf` shim is on PATH
-
-Fix it where it still applies (non-resolved Linux):
-```bash
-sudo apt install openresolv          # Debian/Ubuntu without resolved
-sudo zypper install openresolv       # openSUSE
-```
-
-If you're on a resolved host and still see this error, your `resolvectl` probe is failing — run `resolvectl --version` to debug, then file an issue with the output.
-
-#### Q: Connection fails with "iptables-restore: unable to initialize table"
-
-**A:** Your system doesn't have the `ip_tables` kernel module. This typically happens on:
-- **Cloud providers** (DigitalOcean, AWS Lambda, Google Cloud Run, etc.) that intentionally disable netfilter
-- **Containers** with minimal kernel capabilities
-- **Custom kernels** built without netfilter support
-
-This is **not a Vortix issue** — it's a system limitation that affects all Linux VPN tools, specifically:
-- **Vortix's kill switch** (requires iptables/nftables for firewall rules)
-- **wg-quick's automatic routing** (when `AllowedIPs = 0.0.0.0/0` is set in the WireGuard config)
-
-**Workaround 1: Disable the kill switch (doesn't help on cloud providers):**
-```bash
-sudo vortix killswitch off
-sudo vortix up your-profile
-```
-
-This only works if your WireGuard profile doesn't use `AllowedIPs = 0.0.0.0/0`. If it does, wg-quick will still try to configure iptables.
-
-**Workaround 2: Modify your WireGuard profile for cloud providers:**
-
-If your profile has `AllowedIPs = 0.0.0.0/0` (route all traffic through VPN), wg-quick automatically configures firewall rules. On cloud providers, change it to a more restrictive setting:
-
-```ini
-# ❌ This requires iptables (will fail on cloud providers)
-AllowedIPs = 0.0.0.0/0
-
-# ✅ This only routes VPN subnet (no iptables needed)
-AllowedIPs = 10.0.0.0/8
-```
-
-Edit your profile with `vortix show <profile> --raw` to see the current `AllowedIPs` setting.
-
-**Verify if your system supports iptables:**
-```bash
-modprobe ip_tables && echo "✓ Supported" || echo "✗ Not available on this kernel"
-```
-
-**Best practice for cloud providers:**
-If you need to route all traffic through the VPN on a cloud provider, you'll need an instance with a standard kernel (not a restricted cloud kernel). Alternatively, use a home server, dedicated host, or bare metal with full kernel support.
-
-#### Q: How do I know what DNS resolver my system uses?
-
-**A:** Run this to check which method Vortix will use:
-
-```bash
-# Systemd (most modern Linux distros)
-resolvectl status 2>/dev/null && echo "✓ Using systemd-resolved"
-
-# NetworkManager
-nmcli dev show 2>/dev/null | grep DNS && echo "✓ Using NetworkManager"
-
-# Fallback check
-cat /etc/resolv.conf | head -3
-```
-
-Vortix automatically detects and respects your system's DNS setup.
-
-#### Q: Can I use Vortix on non-systemd distros?
-
-**A:** Yes, but with limitations on DNS management:
-- **Arch, Fedora, Ubuntu, Debian** → Full support (systemd or alternatives available)
-- **Alpine, Void, Gentoo (OpenRC)** → Vortix falls back to editing `/etc/resolv.conf` directly
-- **NixOS** → Works, but DNS may require custom configuration
-
-If you use a non-systemd distro and hit issues, please [open an issue](https://github.com/Harry-kp/vortix/issues) with `vortix report` output.
-
-#### Q: Why does the connection succeed but DNS doesn't work?
-
-**A:** If `vortix up` succeeds but you can't resolve domains, it means:
-
-1. **The VPN tunnel is active** (IP changing works)
-2. **DNS configuration failed** (resolvconf not working properly)
-
-**Debug steps:**
-```bash
-# Check if resolvconf is working
-resolvconf --version
-
-# Check active DNS servers
-resolvectl status | grep -A5 "DNS Servers"
-
-# Manually test DNS through the VPN
-dig @8.8.8.8 google.com
-
-# Check the system's resolv.conf symlink
-ls -la /etc/resolv.conf
-```
-
-If `/etc/resolv.conf` is not managed by systemd (not a symlink to `/run/systemd/`), you may need to install `systemd-resolvconf` or `openresolv`.
-
-#### Q: WireGuard interface name is too long
-
-**A:** Linux WireGuard interfaces have a 15-character name limit. If your profile name is longer, wg-quick will fail with "invalid interface name".
-
-**Fix:** Rename your profile to something shorter:
-```bash
-vortix rename my-very-long-profile-name work-vpn
-```
-
-WireGuard interface names should contain only alphanumeric characters, hyphens, and underscores.
-
-#### Q: How do I report a distro-specific issue?
-
-**A:** Include this information when opening an issue:
-
-```bash
-vortix report              # Generates a complete report
-uname -a                   # Kernel version
-cat /etc/os-release        # Distro info
-systemctl --version        # Init system
-```
-
-Tested and supported Linux distros in CI: **Ubuntu 20.04/22.04**, **Fedora 40+**, **Arch Linux**. If you use a different distro and hit issues, that's valuable signal for the project.
-
-### WireGuard Configuration Guide
-
-#### Understanding AllowedIPs
-
-The `AllowedIPs` setting in your WireGuard config determines what traffic goes through the VPN:
-
-```ini
-# Route ALL traffic through VPN (requires iptables/nftables for firewall rules)
-AllowedIPs = 0.0.0.0/0          # ⚠️ May fail on cloud providers, containers
-
-# Route only VPN subnet traffic (no special firewall rules needed)
-AllowedIPs = 10.0.0.0/8          # ✅ Works everywhere, even cloud providers
-
-# Route specific traffic only
-AllowedIPs = 192.168.1.0/24      # ✅ Route only corporate network
-```
-
-**Why this matters:**
-- When `AllowedIPs = 0.0.0.0/0`, wg-quick automatically configures firewall rules via iptables/nftables
-- Cloud providers (DigitalOcean, AWS Lambda, Google Cloud Run) disable iptables kernel modules
-- Restrictive `AllowedIPs` avoids firewall configuration entirely
-
-**Recommendation for cloud servers:**
-If you're running Vortix on a cloud provider and need to route traffic through the VPN, use `AllowedIPs = 10.0.0.0/8` or another private subnet instead of `0.0.0.0/0`.
-
-#### Common WireGuard Configuration Issues
-
-**Issue: Connection succeeds but no internet access**
-
-Check your `AllowedIPs` setting:
-```bash
-vortix show your-profile --raw | grep AllowedIPs
-```
-
-- If it's `10.0.0.0/8` or similar, only traffic to that subnet goes through VPN
-- Add your target IP/subnet to `AllowedIPs` to route it through the tunnel
-- Example: `AllowedIPs = 10.0.0.0/8, 192.168.0.0/16`
-
-**Issue: Can't reach VPN server from cloud provider**
-
-Some cloud providers block outbound UDP 51820 or other ports. Try:
-```bash
-# Check if you can reach the endpoint
-ping -c 1 138.197.3.155
-
-# Test specific port (replace with your endpoint)
-nc -zu 138.197.3.155 51820 && echo "✓ Port open" || echo "✗ Port blocked"
-```
-
-If blocked, contact your cloud provider to allow WireGuard ports.
-
-**Issue: DNS works but only for some domains**
-
-This usually means:
-1. VPN DNS servers are configured but not all traffic routes through VPN
-2. Your system's DNS fallback is resolving some queries locally
-
-Check if `DNS =` is in your config and matches your VPN provider's DNS servers.
-
-#### Testing Your WireGuard Profile
-
-After creating/importing a profile, test the configuration:
-
-```bash
-# View the profile
-vortix show my-profile --raw
-
-# Check required fields
-vortix show my-profile --raw | grep -E "^(PrivateKey|PublicKey|AllowedIPs|Endpoint|Address|DNS)"
-
-# Expected output:
-# PrivateKey = (base64)
-# Address = 10.0.0.2/24
-# Endpoint = 1.2.3.4:51820
-# AllowedIPs = 10.0.0.0/8 (or 0.0.0.0/0)
-# PublicKey = (base64)
-# DNS = 8.8.8.8, 8.8.4.4 (optional)
-```
-
-All fields above are required except `DNS` (optional).
+Every command supports `--json`; watch commands emit NDJSON. Run `vortix <COMMAND> --help` for authoritative options.
+
+Common TUI keys:
+
+| Key | Action | Key | Action |
+|---|---|---|---|
+| `j` / `k` | Move through profiles | `c` / `Enter` | Connect or disconnect |
+| `Tab` / `Shift-Tab` | Move between panels | `x` | Context action menu |
+| `b` | Bulk action menu | `p` | Switch color theme |
+| `i` | Import profile | `K` | Cycle kill-switch mode |
+| `/` | Search profiles | `?` | Full in-app help |
+| `q` | Quit | `z` | Zoom focused panel |
+
+## Documentation
+
+### For users
+
+| Guide | Covers |
+|---|---|
+| [Usage](https://github.com/Harry-kp/vortix/blob/main/docs/usage.md) | TUI keys, CLI commands, JSON, multi-tunnel behavior, and automation |
+| [Configuration](https://github.com/Harry-kp/vortix/blob/main/docs/configuration.md) | Paths, files, themes, settings, DNS integration, and precedence |
+| [Troubleshooting](https://github.com/Harry-kp/vortix/blob/main/docs/troubleshooting.md) | Startup, permissions, DNS, WireGuard, OpenVPN, firewall, and reporting |
+| [Migration](https://github.com/Harry-kp/vortix/blob/main/docs/MIGRATION.md) | Upgrade and profile-storage changes |
+| [Manual test backlog](https://github.com/Harry-kp/vortix/blob/main/docs/manual-testing/backlog.md) | Real-kernel and real-terminal checks not covered by automation |
+
+### For contributors and agents
+
+| Guide | Covers |
+|---|---|
+| [Contributing](https://github.com/Harry-kp/vortix/blob/main/CONTRIBUTING.md) | Development workflow and contribution entry points |
+| [CI parity](https://github.com/Harry-kp/vortix/blob/main/docs/ci-parity.md) | The exact checks to run before pushing |
+| [Architecture migration](https://github.com/Harry-kp/vortix/blob/main/docs/architecture-migration-v1.md) | Control-plane boundaries and migration direction |
+| [Privileged-helper threat model](https://github.com/Harry-kp/vortix/blob/main/docs/security/privileged-helper-threat-model.md) | Authority, ownership, replay, and recovery invariants |
+| [Project board](https://github.com/users/Harry-kp/projects/6) | Active and planned work |
 
 ## Contributing
 
-PRs welcome — see [CONTRIBUTING.md](https://github.com/Harry-kp/vortix/blob/main/CONTRIBUTING.md) for the dev workflow, CI parity commands, and architectural boundaries enforced by `cargo xtask check-*`.
+Contributions and real-world testing are welcome:
 
-Easy ways in:
+- Start with a [good first issue](https://github.com/Harry-kp/vortix/labels/good%20first%20issue).
+- Run a scenario from the [manual-testing backlog](https://github.com/Harry-kp/vortix/blob/main/docs/manual-testing/backlog.md).
+- Share Linux results in the [Linux tester discussion](https://github.com/Harry-kp/vortix/discussions/184).
+- Use [Discussions](https://github.com/Harry-kp/vortix/discussions) for questions and ideas.
 
-- **[good first issue](https://github.com/Harry-kp/vortix/labels/good%20first%20issue)** — small, scoped tasks with full context in the issue body.
-- **[Manual-testing backlog](https://github.com/Harry-kp/vortix/blob/main/docs/manual-testing/backlog.md)** — one row per scenario that automated tests can't cover (real kernels, real terminals, real distro quirks). Pick a row, run it on your hardware, post results.
-- **[Linux tester discussion](https://github.com/Harry-kp/vortix/discussions/184)** — if you're on Arch / Fedora / NixOS / Debian, your distro-specific bug reports are disproportionately valuable.
-- **[Discussions](https://github.com/Harry-kp/vortix/discussions)** — best place for "should this work?" / "is this a bug?" questions before opening an issue.
+Development starts with `cargo build`, `cargo test`, and the full [CI parity](https://github.com/Harry-kp/vortix/blob/main/docs/ci-parity.md) suite before pushing. Nix users can run `nix develop` for the project shell.
 
-## Roadmap
+## Featured in
 
-See the [project board](https://github.com/users/Harry-kp/projects/6) for what's being explored. Have an idea? [Join the discussion](https://github.com/Harry-kp/vortix/discussions/34).
+[awesome-rust](https://github.com/rust-unofficial/awesome-rust) · [awesome-ratatui](https://github.com/ratatui/awesome-ratatui) · [awesome-tuis](https://github.com/rothgar/awesome-tuis) · [Arch Linux extra](https://archlinux.org/packages/extra/x86_64/vortix/) · [Terminal Trove](https://terminaltrove.com/vortix/)
 
-## Development
-
-```bash
-cargo build         # Build binary
-cargo test          # Run unit/integration tests
-cargo clippy        # Enforce code quality (Fail-fast via pre-commit)
-```
-
-**Nix users** can enter a development shell with all Rust tooling pre-configured:
-```bash
-nix develop
-```
-
-## Featured In
-
-- [awesome-rust](https://github.com/rust-unofficial/awesome-rust) — A curated list of Rust code and resources
-- [awesome-ratatui](https://github.com/ratatui/awesome-ratatui) — A curated list of Ratatui apps and tools
-- [awesome-tuis](https://github.com/rothgar/awesome-tuis) — A list of the best TUI programs
-- [Arch Linux [extra]](https://archlinux.org/packages/extra/x86_64/vortix/) — Official Arch Linux package repository
-- [Terminal Trove](https://terminaltrove.com/vortix/) — The $HOME of all things in the terminal
-
-## Star History
+## Star history
 
 [![Star History Chart](https://star-history.dera.page/svg?repos=Harry-kp/vortix&type=Date)](https://star-history.dera.page/#Harry-kp/vortix&Date)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,144 @@
+# Configuring Vortix
+
+Vortix works without a configuration file. Add only the settings you want to override.
+
+## Config directory
+
+The default user configuration directory is:
+
+- macOS and Linux: `~/.config/vortix`
+- XDG override: `${XDG_CONFIG_HOME}/vortix`
+
+Resolution order is:
+
+1. `--config-dir <PATH>`
+2. `VORTIX_CONFIG_DIR`
+3. the invoking user's home, including when Vortix runs through `sudo`
+4. the platform default
+
+Use `vortix info` to see the paths resolved on your machine.
+
+Vortix keeps user files owned by the invoking user even when tunnel operations run as root. Do not run `sudo cargo build`; build as your user and elevate only the Vortix process.
+
+## Managed files
+
+```text
+~/.config/vortix/
+├── profiles/          imported profiles and identity sidecars
+├── auth/              saved OpenVPN credentials
+├── run/               transient tunnel runtime files
+├── logs/              application logs
+├── config.toml        optional UI and legacy runtime settings
+├── settings.toml      optional layered engine settings
+├── metadata.json      profile metadata such as last-used time
+├── killswitch.state   persisted kill-switch preference
+└── real-ip.cache      last observed un-tunneled identity
+```
+
+Treat `profiles/` as Vortix-managed storage. Import new files from outside it with `vortix import`; do not copy files into the directory while Vortix is running. Identity sidecars and runtime files are internal and may change between releases.
+
+Session journals are observability data, so they use the platform data directory rather than the config directory:
+
+- Linux: `~/.local/share/vortix/sessions/`
+- macOS: `~/Library/Application Support/vortix/sessions/`
+
+## `config.toml`
+
+Create `~/.config/vortix/config.toml` with any subset of these fields:
+
+```toml
+# Appearance
+theme = "synthwave"
+
+# UI and telemetry timing
+tick_rate = 1000
+telemetry_poll_rate = 30
+api_timeout = 5
+ping_timeout = 2
+
+# Connection deadlines and retry policy
+connect_timeout = 35
+wireguard_handshake_timeout_secs = 20
+wireguard_handshake_stale_secs = 180
+disconnect_timeout = 30
+connect_max_retries = 3
+connect_retry_base_delay_secs = 2
+connect_retry_max_delay_secs = 300
+auto_reconnect = true
+auto_reconnect_delay_secs = 3
+
+# Event log and files
+log_level = "info"
+max_log_entries = 1000
+log_rotation_size = 5242880
+log_retention_days = 7
+
+# OpenVPN
+openvpn_verbosity = "3"
+
+# Network probes
+ping_targets = ["1.1.1.1", "8.8.8.8", "9.9.9.9", "208.67.222.222"]
+ipv6_check_apis = [
+  "https://ipv6.icanhazip.com",
+  "https://v6.ident.me",
+  "https://api6.ipify.org",
+]
+ip_api_primary = "https://ipinfo.io/json"
+ip_api_fallbacks = [
+  "https://api.ipify.org",
+  "https://icanhazip.com",
+  "https://ifconfig.me/ip",
+]
+geolocation_api_fallback = "https://ipwho.is"
+```
+
+Unknown fields are rejected so misspellings do not silently change protection behavior.
+
+### Themes
+
+Available values are:
+
+- `synthwave` (default)
+- `terminal` (inherits terminal foreground and background colors)
+- `catppuccin-mocha`
+- `dracula`
+- `nord`
+- `gruvbox-dark`
+- `tokyo-night`
+
+Press `p` in the TUI to cycle themes. Vortix updates only the top-level `theme` key and preserves the rest of `config.toml`, including comments.
+
+Use `terminal` when you want Vortix to follow a terminal application's light or dark palette. Fixed themes use their own colors and are intended for dark terminal backgrounds.
+
+## Layered engine settings
+
+`settings.toml` is the newer layered configuration surface for engine policy. Its precedence is:
+
+1. built-in defaults
+2. system settings
+3. user `settings.toml`
+4. `VORTIX_*` environment variables
+
+`config.toml` remains supported for compatibility and appearance. Prefer the documented engine settings when a field exists in both places. Run `vortix info` to inspect the active files, and consult command help before automating an engine setting that may evolve.
+
+## DNS integration
+
+Vortix applies and verifies the DNS policy declared by the selected VPN topology:
+
+- macOS uses the System Configuration framework.
+- systemd-resolved hosts use per-link DNS registration.
+- NetworkManager and resolvconf environments use their native integration.
+- Non-systemd systems may use a guarded `/etc/resolv.conf` fallback.
+
+On Linux, a WireGuard profile containing `DNS =` needs a working host resolver integration. systemd-resolved hosts normally need no extra package. A host without resolved may require `openresolv` or the distribution's equivalent.
+
+Vortix distinguishes the DNS server currently projected by the OS from DNS-policy verification. A visible server is not, by itself, proof that every resolver route matches the intended tunnel.
+
+## Profile and credential safety
+
+- WireGuard and inline OpenVPN secrets remain in the imported profile and are masked in normal display output.
+- Saved OpenVPN username/password material lives under `auth/` and is owner-restricted.
+- OpenVPN external key and PKCS#12 references are validated before activation; unsupported ownership or recovery shapes fail closed.
+- Do not publish `show --raw`, runtime logs, or generated reports without reviewing them for provider-specific data.
+
+For upgrade-related storage changes, see [Migration](MIGRATION.md). For common failures, see [Troubleshooting](troubleshooting.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,204 @@
+# Troubleshooting Vortix
+
+Start with:
+
+```bash
+vortix info
+vortix report
+```
+
+`vortix report` is the preferred attachment for an issue. Review the generated report before posting if your VPN provider treats endpoint addresses as sensitive.
+
+## Quick diagnosis
+
+| Symptom | Likely cause | First action |
+|---|---|---|
+| `sudo: vortix: command not found` | `sudo` does not include the install directory in `PATH` | Link the binary into `/usr/local/bin` |
+| A second Vortix instance exits | Another process owns the lifecycle lock | Use or close the running instance |
+| Profile import rejects a name | Invalid or overlong WireGuard interface name | Rename the source file and import it again |
+| Connect stays transitional | The durable operation has not reached a terminal observation | Use `vortix status` and query the reported operation ID |
+| Connected split tunnel does not change public IP | The profile does not own the default route | Test a destination included in its declared routes |
+| Connected tunnel cannot resolve names | DNS application, read-back, or resolver routing failed | Inspect the DNS section below |
+| Kill switch blocks all traffic | `vpn-only` is active without an effective tunnel | Connect a VPN or use `release-kill-switch` in an emergency |
+| Full-tunnel WireGuard fails on Linux | Missing kernel networking/firewall capability | Check nftables/iptables and kernel support |
+
+## Installation and privileges
+
+### Cargo install is not visible to `sudo`
+
+Linux commonly omits `~/.cargo/bin` from sudo's secure path:
+
+```bash
+sudo ln -s ~/.cargo/bin/vortix /usr/local/bin/vortix
+```
+
+Homebrew, pacman, npm global installs, and packaged release binaries normally install into an already-visible path.
+
+### A build directory became root-owned
+
+Build as your user. If an earlier `sudo cargo build` changed ownership:
+
+```bash
+sudo chown -R "$(id -un):$(id -gn)" target
+cargo build --bin vortix
+sudo ./target/debug/vortix
+```
+
+### Running without root exits
+
+The interactive dashboard owns tunnel lifecycle and must be started with `sudo vortix`. Read-only CLI commands remain available without root.
+
+## Profiles and upgrades
+
+Vortix validates the managed profile inventory and identity sidecars to avoid adopting the wrong secret file after an interrupted migration or external edit.
+
+- Import from outside `~/.config/vortix/profiles/`.
+- Do not place `.vortix-*` runtime files or hand-written sidecars in the managed directory.
+- If startup reports an unexplained sidecar or changed inventory, stop and inspect the directory rather than deleting files blindly.
+- Follow [Migration](MIGRATION.md) for release-specific recovery steps.
+
+If files were created under the wrong account, restore invoking-user ownership:
+
+```bash
+sudo chown -R "$(id -un):$(id -gn)" ~/.config/vortix
+```
+
+## Connection state
+
+### A CLI command timed out
+
+A timeout does not erase the operation. Vortix keeps the command in durable history because the OS effect may still be reconciling.
+
+```bash
+vortix status
+vortix status --operation <OPERATION_ID>
+```
+
+Do not repeatedly submit the same connect or disconnect while the earlier operation still owns the profile. If the TUI and CLI appear different, ensure both were built from and are running the same binary and config directory.
+
+### Split-route tunnel shows the normal public IP
+
+This is expected if the profile does not claim `0.0.0.0/0` or `::/0`. Verify a routed destination instead:
+
+```bash
+route -n get 10.250.0.1        # macOS example
+ip route get 10.250.0.1        # Linux example
+ping -c 3 10.250.0.1
+```
+
+The Security Guard should describe a split-route tunnel as having no exit rather than treating the unchanged public IP as a leak.
+
+## DNS
+
+Vortix treats DNS as a policy transition, not just a line in a profile. A successful connection requires the intended resolver state to be applied and read back safely; on failure Vortix restores the previous network settings.
+
+### Inspect the active resolver
+
+```bash
+# macOS
+scutil --dns
+
+# systemd-resolved Linux
+resolvectl status
+
+# NetworkManager Linux
+nmcli device show | grep -i dns
+
+# Generic fallback
+cat /etc/resolv.conf
+```
+
+Then test the intended VPN resolver directly:
+
+```bash
+dig +time=3 +tries=1 @<VPN_DNS_IP> example.com
+```
+
+Direct `dig` success proves the server is reachable; it does not prove the operating system's ordinary resolver selected it. Test both ordinary resolution and fixed-IP HTTPS to separate DNS from data-plane failures:
+
+```bash
+curl -4 --max-time 15 https://cloudflare.com/cdn-cgi/trace
+curl -4 --max-time 15 \
+  --resolve cloudflare.com:443:104.16.132.229 \
+  https://cloudflare.com/cdn-cgi/trace
+```
+
+### Linux resolver dependencies
+
+- systemd-resolved: Vortix uses per-link DNS; no resolvconf shim should be necessary.
+- Hosts without resolved: install `openresolv` or the distribution equivalent if the profile declares `DNS =`.
+- Non-systemd systems: confirm the guarded `/etc/resolv.conf` fallback is permitted and that another manager is not immediately replacing it.
+
+If system DNS is externally managed by device policy, another VPN client, or enterprise software, Vortix may be unable to prove safe replacement. This is a host-policy conflict, not an authentication failure.
+
+## WireGuard
+
+### Profile name rejected
+
+WireGuard interface names have platform length and character constraints. Vortix validates them during import and again before connection. Rename the source file to a short identifier such as `work.conf`, then import it again.
+
+### No handshake
+
+Compare Vortix with the system tool using the same profile:
+
+```bash
+sudo wg show
+```
+
+Check the endpoint, peer public key, local private key, preshared key, and UDP reachability. A configured interface without a recent handshake is not considered connected.
+
+### `AllowedIPs` behavior
+
+`AllowedIPs` controls both peer selection and routing:
+
+```ini
+AllowedIPs = 0.0.0.0/0, ::/0       # full tunnel
+AllowedIPs = 10.0.0.0/8            # split tunnel
+AllowedIPs = 10.0.0.0/8, 192.168.0.0/16
+```
+
+Full-tunnel setup may require nftables/iptables support on Linux. Restricted containers or custom kernels may not expose the required capabilities; use a normal host kernel or a split-route profile appropriate to the environment.
+
+## OpenVPN
+
+OpenVPN runtime logs live under `~/.config/vortix/run/` while a session exists. Look for the exact server or management response:
+
+```bash
+vortix info
+sudo find ~/.config/vortix/run -name '*.log' -maxdepth 1 -print
+```
+
+Common distinctions:
+
+- `AUTH_FAILED`: credentials or challenge response were rejected by the server.
+- TLS timeout: endpoint reachability, certificates, protocol, or server configuration.
+- Initialization succeeds but traffic fails: inspect pushed routes, DNS policy, forwarding, and NAT on the VPN server.
+- A management hold that never releases: report it with the runtime log; Vortix should surface a terminal error rather than leave the profile indefinitely connecting.
+
+To isolate orchestration from a provider/server problem, test the same profile with the installed `openvpn` binary. Remove Vortix-specific runtime state from the comparison; do not rewrite the profile semantics just to make the test pass.
+
+## Firewall and kill switch
+
+Vortix uses PF on macOS and nftables or iptables on Linux. If `vpn-only` leaves you without connectivity after a crash:
+
+```bash
+sudo vortix release-kill-switch
+```
+
+On Linux, verify the chosen backend is present and supported by the running kernel. An error from `iptables-restore` or nft does not imply every cloud VM is unsupported; inspect that host's modules, capabilities, and container restrictions.
+
+Kill-switch rules may be flushed by reboot. Check and re-arm the desired mode after boot.
+
+## Reporting a problem
+
+Include:
+
+```bash
+vortix report
+vortix --version
+uname -a
+```
+
+Linux reports should also include `/etc/os-release`, resolver choice, and firewall backend. Describe whether the same profile works with `wg-quick` or `openvpn` directly, and whether it is full-tunnel or split-route.
+
+Open an [issue](https://github.com/Harry-kp/vortix/issues) for reproducible defects or use [Discussions](https://github.com/Harry-kp/vortix/discussions) when you are unsure whether observed behavior is expected.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,168 @@
+# Using Vortix
+
+Vortix exposes one VPN control engine through an interactive terminal dashboard, a blocking CLI, and versioned machine-readable output.
+
+## Start the dashboard
+
+```bash
+sudo vortix
+```
+
+Root is required for tunnel, route, DNS, and firewall changes. Read-only commands such as `vortix list`, `vortix show`, and `vortix status` can run without it.
+
+If another Vortix process already owns the lifecycle lock, use the running instance or close it before starting a second interactive instance.
+
+## TUI keys
+
+Press `?` at any time for the complete in-app reference. The most frequently used keys are:
+
+### Global
+
+| Key | Action |
+|---|---|
+| `1`–`9` | Quick-connect to profile N |
+| `d` | Disconnect, cancel, or force-kill the focused tunnel according to its phase |
+| `D` | Disconnect every active tunnel |
+| `r` | Reconnect |
+| `i` | Import a profile, directory, or URL |
+| `K` | Cycle the kill-switch mode |
+| `Tab` / `Shift-Tab` | Move between panels |
+| `F1`–`F5` | Jump directly to a dashboard panel |
+| `z` | Zoom the focused panel |
+| `x` | Open the context action menu |
+| `b` | Open bulk actions |
+| `p` | Switch color theme |
+| `/` | Search profiles |
+| `?` | Open help |
+| `q` | Quit |
+
+### Profiles
+
+| Key | Action |
+|---|---|
+| `j` / `↓`, `k` / `↑` | Move selection |
+| `g` / `Home`, `G` / `End` | First or last profile |
+| `c` / `Enter` | Connect or disconnect the selected profile |
+| `R` | Rename |
+| `v` | View configuration |
+| `s` | Change sort order |
+| `a` | Manage OpenVPN credentials |
+| `A` | Clear saved OpenVPN credentials |
+| `Delete` | Delete the selected profile |
+
+The Connection Details panel follows the selected profile. When a tunnel is in flight, `c` cancels the connection attempt. The log panel uses `j` / `k` to scroll, `f` to filter, and `L` to clear the visible log.
+
+## Profiles
+
+Vortix recognizes WireGuard `.conf` and OpenVPN `.ovpn` / `.conf` files. Imports validate and copy the profile into the managed profile directory; keep source files outside that directory.
+
+```bash
+vortix import ./work.conf        # one local file
+vortix import ./profiles/        # supported files in a directory
+vortix import https://example.com/work.ovpn
+
+vortix list
+vortix list --sort last-used
+vortix list --protocol wireguard
+vortix list --names-only
+
+vortix show work                # parsed, secrets masked
+vortix show work --raw
+vortix rename work work-eu
+vortix delete work-eu --yes
+```
+
+WireGuard profile names must also be valid platform interface names. If an import reports that the name is too long or invalid, rename the source file and import it again.
+
+## Connections
+
+```bash
+sudo vortix up work
+sudo vortix up work --timeout 60
+sudo vortix down work
+sudo vortix down --all
+sudo vortix reconnect work
+```
+
+Without a profile, `down` disconnects every active tunnel and `reconnect` cycles every connected tunnel. Both are idempotent at their terminal state.
+
+### Multi-tunnel behavior
+
+Multiple tunnels may be connected at once:
+
+- The **primary** tunnel owns the kernel default route.
+- A **split-route** tunnel carries only the destinations declared by its WireGuard `AllowedIPs` or OpenVPN route directives.
+- Vortix rejects overlapping routes or default-route takeovers before connection unless an interactive user confirms the choice or a script passes `--yes`.
+- Disconnecting one profile does not disconnect unrelated active profiles.
+
+Use bypass flags only after reviewing the routes:
+
+```bash
+sudo vortix up second-vpn --yes
+```
+
+## Status and durable operations
+
+```bash
+vortix status
+vortix status --brief
+vortix status --watch
+vortix status --operation op-0000000000000001-0000000000000001
+```
+
+If a blocking CLI command times out, its operation remains recorded for reconciliation. Query the operation ID reported by the command rather than immediately assuming the tunnel failed.
+
+## Kill switch
+
+The same three labels are used in CLI input, CLI output, JSON, and the TUI:
+
+| Mode | Behavior |
+|---|---|
+| `off` | No firewall rules; normal traffic is allowed |
+| `block-on-drop` | Blocks egress after an unexpected VPN drop |
+| `vpn-only` | Keeps default-deny egress protection active with or without a connected VPN |
+
+```bash
+vortix killswitch
+sudo vortix killswitch off
+sudo vortix killswitch block-on-drop
+sudo vortix killswitch vpn-only
+sudo vortix release-kill-switch      # emergency firewall release
+```
+
+The OS may flush firewall state on reboot. Re-arm `vpn-only` after each boot.
+
+## Diagnostics and system commands
+
+```bash
+vortix info
+vortix report
+vortix audit
+vortix audit --pid 12345
+vortix audit --vpn-only
+vortix completions zsh > ~/.zfunc/_vortix
+vortix update
+```
+
+`vortix audit` is a point-in-time process socket and route inspection tool. It does not continuously intercept traffic.
+
+## JSON and automation
+
+Every command supports `--json`. Successful and failed one-shot commands use a versioned envelope containing `schema_version`, `ok`, `command`, `data`, and `next_actions`. Watch commands emit one JSON object per line (NDJSON).
+
+```bash
+vortix list --json
+vortix status --json
+vortix status --watch --json
+sudo vortix up work --json
+```
+
+Current status output is multi-tunnel aware:
+
+- `data.connections` contains active and transitional tunnels.
+- `data.primary` names the default-route owner, or is `null`.
+- `data.connection` is retained for single-tunnel compatibility and is `null` when that shape would be ambiguous.
+
+Stable exit categories allow scripts to distinguish usage errors, permission failures, state conflicts, missing dependencies, and timeouts. Run `vortix --help` for the current numeric mapping and `vortix <COMMAND> --help` for authoritative flags.
+
+For file locations and settings, see [Configuration](configuration.md). For failure recovery, see [Troubleshooting](troubleshooting.md).


### PR DESCRIPTION
## What does this PR do?

The repository README is now a concise project entry point instead of an 835-line all-in-one manual. A new reader can understand the product, install it, start it, assess platform and security expectations, and reach the right detailed guide without scrolling through operational reference material.

Detailed CLI/TUI usage, configuration, and troubleshooting guidance now live in focused guides. The split also removes repeated and stale claims, corrects the emergency kill-switch command, and aligns documented runtime defaults with the current code.

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📖 Documentation
- [ ] 🔧 Refactor
- [ ] 🧪 Tests

## Validation

- README reduced from 835 lines / 5,808 words to 209 lines / 1,191 words.
- All 18 repository-local links resolve.
- The documented `config.toml` example parses with all 24 supported fields.
- All 16 documented top-level commands match the generated CLI help.
- Full local CI parity passed: format, workspace check, strict clippy, workspace tests, rustdoc, and all five architectural boundary checks.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This PR changes inert Markdown documentation only and does not alter the binary, runtime configuration, or release workflow.

After merge, verify the README and its three linked guides render correctly on GitHub and that the absolute documentation links also work from the crates.io README.

## Checklist

- [x] I ran `cargo fmt`
- [x] I ran `cargo clippy` with no warnings
- [x] I ran `cargo test` and all tests pass
- [x] I updated documentation if needed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
